### PR TITLE
Add Maven formatter and import sort

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,4 +28,4 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B  formatter:validate impsort:check package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
 
   <groupId>io.mvnpm</groupId>
   <artifactId>esbuild-java</artifactId>
-  <name>esbuild wrapper for java</name>
+  <name>esbuild wrapper for Java</name>
   <version>1.0.5-SNAPSHOT</version>
-  
-  <description>Small wrapper around esbuild to be able to use it in java</description>
+
+  <description>Small wrapper around esbuild to be able to use it in Java</description>
 
   <url>https://github.com/mvnpm/esbuild-java/</url>
   <scm>
@@ -35,9 +35,20 @@
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <esbuild.version>0.19.2</esbuild.version>
     <quarkus.version>3.3.2</quarkus.version>
+    <formatter.plugin.version>2.23.0</formatter.plugin.version>
+    <impsort.plugin.version>1.9.0</impsort.plugin.version>
+    <quarkus.ide-config.version>3.0.0.Final</quarkus.ide-config.version>
+    <surefire.plugin.version>3.1.2</surefire.plugin.version>
+    <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
+    <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
+    <properties-maven-plugin.version>1.2.0</properties-maven-plugin.version>
+    <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
+    <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
+    <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -58,7 +69,7 @@
       <artifactId>importmap</artifactId>
       <version>1.0.10</version>
     </dependency>
-      
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
@@ -73,7 +84,7 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
     </dependency>
-   
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
@@ -102,12 +113,12 @@
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>${surefire.plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>${maven-antrun-plugin.version}</version>
         <executions>
           <execution>
             <id>download</id>
@@ -134,7 +145,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>properties-maven-plugin</artifactId>
-        <version>1.2.0</version>
+        <version>${properties-maven-plugin.version}</version>
         <executions>
           <execution>
             <phase>generate-resources</phase>
@@ -150,6 +161,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>${maven-assembly-plugin.version}</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -168,6 +180,48 @@
                 <descriptorRef>jar-with-dependencies</descriptorRef>
               </descriptorRefs>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>net.revelc.code.formatter</groupId>
+        <artifactId>formatter-maven-plugin</artifactId>
+        <version>${formatter.plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-ide-config</artifactId>
+            <version>${quarkus.ide-config.version}</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <configFile>eclipse-format.xml</configFile>
+          <lineEnding>LF</lineEnding>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>net.revelc.code</groupId>
+        <artifactId>impsort-maven-plugin</artifactId>
+        <version>${impsort.plugin.version}</version>
+        <configuration>
+          <groups>java.,javax.,jakarta.,org.,com.</groups>
+          <staticGroups>*</staticGroups>
+          <removeUnused>true</removeUnused>
+        </configuration>
+        <executions>
+          <execution>
+            <id>sort-imports</id>
+            <goals>
+              <goal>sort</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>
@@ -193,7 +247,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.3.0</version>
+            <version>${maven-source-plugin.version}</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -206,7 +260,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.5.0</version>
+            <version>${maven-javadoc-plugin.version}</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -219,7 +273,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>${maven-gpg-plugin.version}</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/src/main/java/io/mvnpm/esbuild/BuildEventListener.java
+++ b/src/main/java/io/mvnpm/esbuild/BuildEventListener.java
@@ -2,6 +2,5 @@ package io.mvnpm.esbuild;
 
 public interface BuildEventListener {
 
-
     void onChange();
 }

--- a/src/main/java/io/mvnpm/esbuild/BundleException.java
+++ b/src/main/java/io/mvnpm/esbuild/BundleException.java
@@ -3,6 +3,7 @@ package io.mvnpm.esbuild;
 public class BundleException extends RuntimeException {
 
     private final String output;
+
     public BundleException(String message, String output) {
         super(message);
         this.output = output;

--- a/src/main/java/io/mvnpm/esbuild/Bundler.java
+++ b/src/main/java/io/mvnpm/esbuild/Bundler.java
@@ -1,5 +1,19 @@
 package io.mvnpm.esbuild;
 
+import static io.mvnpm.esbuild.util.Copy.deleteRecursive;
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import io.mvnpm.esbuild.model.BundleOptions;
 import io.mvnpm.esbuild.model.BundleResult;
 import io.mvnpm.esbuild.model.BundleType;
@@ -9,41 +23,25 @@ import io.mvnpm.esbuild.resolve.ExecutableResolver;
 import io.mvnpm.esbuild.util.JarInspector;
 import io.mvnpm.esbuild.util.UnZip;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.util.List;
-import java.util.Properties;
-
-import static io.mvnpm.esbuild.util.Copy.deleteRecursive;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 public class Bundler {
     private static final Logger logger = Logger.getLogger(Bundler.class.getName());
-    
+
     private static final String NODE_MODULES = "node_modules";
     private static final String DIST = "dist";
-    private static String VERSION;
+    public static final String ESBUILD_EMBEDDED_VERSION = resolveEmbeddedVersion();
 
-    public static String getDefaultVersion() {
-        if (VERSION == null) {
-            Properties properties = new Properties();
-            try {
-                final InputStream resource = Bundler.class.getResourceAsStream("/version.properties");
-                if (resource != null) {
-                    properties.load(resource);
-                }
-            } catch (IOException e) {
-                // ignore we use the default
+    private static String resolveEmbeddedVersion() {
+        Properties properties = new Properties();
+        try {
+            final InputStream resource = Bundler.class.getResourceAsStream("/version.properties");
+            if (resource != null) {
+                properties.load(resource);
             }
-            VERSION = properties.getProperty("esbuild.version", "0.19.2");
+        } catch (IOException e) {
+            // ignore we use the default
         }
-
-        return VERSION;
+        String version = properties.getProperty("esbuild.version");
+        return requireNonNull(version, "Make sure the version.properties contains 'esbuild.version'.");
     }
 
     /**
@@ -60,7 +58,7 @@ public class Bundler {
 
         final ExecuteResult executeResult = esBuild(esBuildConfig);
 
-        if(!Files.isDirectory(dist)) {
+        if (!Files.isDirectory(dist)) {
             throw new BundleException("Unexpected Error during bundling", executeResult.output());
         }
 
@@ -89,14 +87,15 @@ public class Bundler {
     }
 
     public static Path installIfNeeded(BundleOptions bundleOptions) throws IOException {
-        if(bundleOptions.getWorkDir() != null && Files.isDirectory(bundleOptions.getWorkDir().resolve(NODE_MODULES))) {
+        if (bundleOptions.getWorkDir() != null && Files.isDirectory(bundleOptions.getWorkDir().resolve(NODE_MODULES))) {
             return bundleOptions.getWorkDir();
         }
         return install(bundleOptions);
     }
 
     public static Path install(BundleOptions bundleOptions) throws IOException {
-        final Path workingDir = bundleOptions.getWorkDir() != null ? bundleOptions.getWorkDir() : Files.createTempDirectory("bundle");
+        final Path workingDir = bundleOptions.getWorkDir() != null ? bundleOptions.getWorkDir()
+                : Files.createTempDirectory("bundle");
         return extract(workingDir, bundleOptions.getDependencies(), bundleOptions.getType());
     }
 
@@ -121,9 +120,9 @@ public class Bundler {
             if (!Files.isDirectory(extractDir)) {
                 UnZip.unzip(path, extractDir);
                 final Map<String, Path> packageNameAndRoot = JarInspector.findPackageNameAndRoot(extractDir, type);
-                
-                if(!packageNameAndRoot.isEmpty()) {
-                    for(Map.Entry<String, Path> nameAndRoot: packageNameAndRoot.entrySet()){
+
+                if (!packageNameAndRoot.isEmpty()) {
+                    for (Map.Entry<String, Path> nameAndRoot : packageNameAndRoot.entrySet()) {
                         final String packageName = nameAndRoot.getKey();
                         final Path source = nameAndRoot.getValue();
                         final Path target = nodeModules.resolve(packageName);
@@ -135,7 +134,7 @@ public class Bundler {
                         }
                     }
                 } else {
-                    logger.log(Level.INFO,"package.json not found in package: ''{0}''", fileName);
+                    logger.log(Level.INFO, "package.json not found in package: ''{0}''", fileName);
                 }
             }
         }
@@ -143,19 +142,15 @@ public class Bundler {
     }
 
     protected static Process esBuild(EsBuildConfig esBuildConfig, BuildEventListener listener) throws IOException {
-        final Path esBuildExec = new ExecutableResolver().resolve(Bundler.getDefaultVersion());
+        final Path esBuildExec = new ExecutableResolver().resolve(Bundler.ESBUILD_EMBEDDED_VERSION);
         final Execute execute = new Execute(esBuildExec.toFile(), esBuildConfig);
         return execute.execute(listener);
     }
 
     protected static ExecuteResult esBuild(EsBuildConfig esBuildConfig) throws IOException {
-        final Path esBuildExec = new ExecutableResolver().resolve(Bundler.getDefaultVersion());
+        final Path esBuildExec = new ExecutableResolver().resolve(Bundler.ESBUILD_EMBEDDED_VERSION);
         final Execute execute = new Execute(esBuildExec.toFile(), esBuildConfig);
         return execute.executeAndWait();
     }
 
-    
-    
 }
-
-

--- a/src/main/java/io/mvnpm/esbuild/Execute.java
+++ b/src/main/java/io/mvnpm/esbuild/Execute.java
@@ -1,8 +1,5 @@
 package io.mvnpm.esbuild;
 
-import io.mvnpm.esbuild.model.EsBuildConfig;
-import io.mvnpm.esbuild.model.ExecuteResult;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -19,6 +16,9 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import io.mvnpm.esbuild.model.EsBuildConfig;
+import io.mvnpm.esbuild.model.ExecuteResult;
 
 public class Execute {
 
@@ -87,14 +87,14 @@ public class Execute {
     public Process createProcess(final String[] command, final Optional<BuildEventListener> listener) throws IOException {
         Process process = new ProcessBuilder().command(command).start();
         final InputStream s = process.getErrorStream();
-        if(listener.isPresent()) {
+        if (listener.isPresent()) {
             EXECUTOR.execute(new Streamer(process::isAlive, s, listener.get()));
         }
         return process;
     }
 
-
-    private record Streamer(BooleanSupplier isAlive, InputStream processStream, BuildEventListener listener) implements Runnable {
+    private record Streamer(BooleanSupplier isAlive, InputStream processStream,
+            BuildEventListener listener) implements Runnable {
 
         @Override
         public void run() {
@@ -119,9 +119,8 @@ public class Execute {
 
     private static void consumeStream(BooleanSupplier shouldStop, InputStream stream, Consumer<String> newLineConsumer) {
         try (
-            final InputStreamReader in = new InputStreamReader(stream, StandardCharsets.UTF_8);
-            final BufferedReader reader = new BufferedReader(in)
-        ) {
+                final InputStreamReader in = new InputStreamReader(stream, StandardCharsets.UTF_8);
+                final BufferedReader reader = new BufferedReader(in)) {
             String line;
             while ((line = reader.readLine()) != null && shouldStop.getAsBoolean()) {
                 newLineConsumer.accept(line);
@@ -132,4 +131,3 @@ public class Execute {
     }
 
 }
-

--- a/src/main/java/io/mvnpm/esbuild/Main.java
+++ b/src/main/java/io/mvnpm/esbuild/Main.java
@@ -1,15 +1,15 @@
 package io.mvnpm.esbuild;
 
-import io.mvnpm.esbuild.model.ExecuteResult;
-import io.mvnpm.esbuild.resolve.ExecutableResolver;
-
 import java.io.IOException;
 import java.nio.file.Path;
+
+import io.mvnpm.esbuild.model.ExecuteResult;
+import io.mvnpm.esbuild.resolve.ExecutableResolver;
 
 public class Main {
 
     public static void main(String[] args) throws IOException {
-        final Path esBuildExec = new ExecutableResolver().resolve(Bundler.getDefaultVersion());
+        final Path esBuildExec = new ExecutableResolver().resolve(Bundler.ESBUILD_EMBEDDED_VERSION);
         final ExecuteResult executeResult = new Execute(esBuildExec.toFile(), args).executeAndWait();
         System.out.println(executeResult.output());
     }

--- a/src/main/java/io/mvnpm/esbuild/Watch.java
+++ b/src/main/java/io/mvnpm/esbuild/Watch.java
@@ -1,9 +1,9 @@
 package io.mvnpm.esbuild;
 
+import static io.mvnpm.esbuild.util.Copy.copyEntries;
+
 import java.nio.file.Path;
 import java.util.List;
-
-import static io.mvnpm.esbuild.util.Copy.copyEntries;
 
 public class Watch {
 

--- a/src/main/java/io/mvnpm/esbuild/model/AutoEntryPoint.java
+++ b/src/main/java/io/mvnpm/esbuild/model/AutoEntryPoint.java
@@ -1,16 +1,16 @@
 package io.mvnpm.esbuild.model;
 
+import static io.mvnpm.esbuild.util.Copy.copyEntries;
+
 import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-
-import static io.mvnpm.esbuild.util.Copy.copyEntries;
-import java.io.StringWriter;
-import java.io.UncheckedIOException;
 
 public class AutoEntryPoint implements EntryPoint {
     private static final Set<String> SCRIPTS = Set.of("js", "ts", "jsx", "tsx", "mjs", "mts", "cjs", "cts");
@@ -23,7 +23,6 @@ public class AutoEntryPoint implements EntryPoint {
         this.rootDir = rootDir;
         this.scripts = scripts;
     }
-
 
     @Override
     public Path process(Path workDir) {
@@ -45,19 +44,19 @@ public class AutoEntryPoint implements EntryPoint {
     }
 
     private String convert(Path workDir, List<String> scripts) {
-        try(StringWriter sw = new StringWriter()){
-            for(String script: scripts){
+        try (StringWriter sw = new StringWriter()) {
+            for (String script : scripts) {
                 final String fileName = Path.of(script).getFileName().toString();
                 final int index = fileName.lastIndexOf(".");
                 String name = fileName.substring(0, index);
                 final String ext = fileName.substring(index + 1);
                 final boolean isScript = SCRIPTS.contains(ext);
                 String line;
-                if(isScript){
+                if (isScript) {
                     script = script.substring(0, script.lastIndexOf("."));
                     name = name.replaceAll("-", "");
                     line = IMPORT_WITH_FROM.formatted(name, script);
-                }else {
+                } else {
                     line = IMPORT_WITHOUT_FROM.formatted(script);
                 }
                 sw.write(line);
@@ -68,7 +67,7 @@ public class AutoEntryPoint implements EntryPoint {
             throw new UncheckedIOException(ex);
         }
     }
-    
+
     private static final String IMPORT_WITH_FROM = "import * as %s from \"./%s\";";
     private static final String IMPORT_WITHOUT_FROM = "import \"./%s\";";
 }

--- a/src/main/java/io/mvnpm/esbuild/model/BundleOptionsBuilder.java
+++ b/src/main/java/io/mvnpm/esbuild/model/BundleOptionsBuilder.java
@@ -4,7 +4,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-
 public class BundleOptionsBuilder {
     private final BundleOptions options = new BundleOptions();
 

--- a/src/main/java/io/mvnpm/esbuild/model/EsBuildConfig.java
+++ b/src/main/java/io/mvnpm/esbuild/model/EsBuildConfig.java
@@ -1,6 +1,5 @@
 package io.mvnpm.esbuild.model;
 
-
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,8 +28,21 @@ public class EsBuildConfig {
     private Format format;
 
     public enum Loader {
-        BASE64, BINARY, COPY, CSS, DATAURL, LOCAL_CSS, GLOBAL_CSS,
-        EMPTY, FILE, JS, JSON, JSX, TEXT, TS, TSX
+        BASE64,
+        BINARY,
+        COPY,
+        CSS,
+        DATAURL,
+        LOCAL_CSS,
+        GLOBAL_CSS,
+        EMPTY,
+        FILE,
+        JS,
+        JSON,
+        JSX,
+        TEXT,
+        TS,
+        TSX
     }
 
     private Map<String, Loader> loader;
@@ -39,7 +51,9 @@ public class EsBuildConfig {
     private String packages;
 
     enum Platform {
-        BROWSER, NODE, NEUTRAL
+        BROWSER,
+        NODE,
+        NEUTRAL
     }
 
     private Platform platform;
@@ -50,8 +64,14 @@ public class EsBuildConfig {
     private boolean splitting;
 
     enum Target {
-        ES2017, CHROME58, FIREFOX57,
-        SAFARI11, EDGE16, NODE10, IE9, OPERA45
+        ES2017,
+        CHROME58,
+        FIREFOX57,
+        SAFARI11,
+        EDGE16,
+        NODE10,
+        IE9,
+        OPERA45
     }
 
     private Target target;
@@ -246,7 +266,7 @@ public class EsBuildConfig {
                     } else if (!(value instanceof Boolean)) {
                         String fn = convertField(fieldName);
                         String v = value.toString();
-                        if(!fn.equals("outdir")){ 
+                        if (!fn.equals("outdir")) {
                             v = v.toLowerCase();
                         }
                         result.add("--%s=%s".formatted(fn, v));
@@ -268,7 +288,8 @@ public class EsBuildConfig {
     private static List<String> mapToString(String fieldName, Map<?, ?> map) {
         List<String> result = new ArrayList<>(map.size());
         for (Map.Entry<?, ?> entry : map.entrySet()) {
-            result.add("--%s:%s=%s".formatted(fieldName, entry.getKey(), entry.getValue().toString().toLowerCase().replaceAll("_", "-")));
+            result.add("--%s:%s=%s".formatted(fieldName, entry.getKey(),
+                    entry.getValue().toString().toLowerCase().replaceAll("_", "-")));
         }
 
         return result;

--- a/src/main/java/io/mvnpm/esbuild/model/EsBuildConfigBuilder.java
+++ b/src/main/java/io/mvnpm/esbuild/model/EsBuildConfigBuilder.java
@@ -1,9 +1,5 @@
 package io.mvnpm.esbuild.model;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import static io.mvnpm.esbuild.model.EsBuildConfig.Loader.CSS;
 import static io.mvnpm.esbuild.model.EsBuildConfig.Loader.FILE;
 import static io.mvnpm.esbuild.model.EsBuildConfig.Loader.JS;
@@ -11,6 +7,10 @@ import static io.mvnpm.esbuild.model.EsBuildConfig.Loader.JSON;
 import static io.mvnpm.esbuild.model.EsBuildConfig.Loader.JSX;
 import static io.mvnpm.esbuild.model.EsBuildConfig.Loader.TS;
 import static io.mvnpm.esbuild.model.EsBuildConfig.Loader.TSX;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class EsBuildConfigBuilder {
     private final EsBuildConfig esBuildConfig;

--- a/src/main/java/io/mvnpm/esbuild/model/FileEntryPoint.java
+++ b/src/main/java/io/mvnpm/esbuild/model/FileEntryPoint.java
@@ -1,13 +1,13 @@
 package io.mvnpm.esbuild.model;
 
+import static io.mvnpm.esbuild.util.Copy.copyEntries;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
-
-import static io.mvnpm.esbuild.util.Copy.copyEntries;
 
 public class FileEntryPoint implements EntryPoint {
 
@@ -26,7 +26,7 @@ public class FileEntryPoint implements EntryPoint {
             return workDir.resolve(script);
         }
         final Path scriptPath = rootDir.resolve(script);
-        if(!Files.exists(scriptPath)) {
+        if (!Files.exists(scriptPath)) {
             throw new UncheckedIOException(new IOException("Entry file not found: " + scriptPath));
         }
         return scriptPath;

--- a/src/main/java/io/mvnpm/esbuild/resolve/BaseResolver.java
+++ b/src/main/java/io/mvnpm/esbuild/resolve/BaseResolver.java
@@ -1,5 +1,7 @@
 package io.mvnpm.esbuild.resolve;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -10,17 +12,20 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Arrays;
 import java.util.HashSet;
-
-import static java.util.Objects.requireNonNull;
 import java.util.Set;
+
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 
 public abstract class BaseResolver {
-    private static final String EXECUTABLE_PATH = "package/bin/esbuild";
+    private static final String UNIX_PATH = "package/bin/esbuild";
     private static final String WINDOWS_EXE_PATH = "package/esbuild.exe";
+
+    public static final String EXECUTABLE_PATH = resolveExecutablePath();
+
+    public static final String CLASSIFIER = determineClassifier();
 
     protected Resolver resolver;
 
@@ -28,15 +33,16 @@ public abstract class BaseResolver {
         this.resolver = requireNonNull(resolver, "resolver is required");
     }
 
-    public static String executablePath() {
-        final String osName = System.getProperty("os.name").toLowerCase();
-        if (osName.contains("win")) {
-            return WINDOWS_EXE_PATH;
-        }
-        return EXECUTABLE_PATH;
+    private static String resolveExecutablePath() {
+        return isWindows() ? WINDOWS_EXE_PATH : UNIX_PATH;
     }
 
-    static String determineClassifier() {
+    private static boolean isWindows() {
+        final String osName = System.getProperty("os.name").toLowerCase();
+        return osName.contains("win");
+    }
+
+    private static String determineClassifier() {
         final String osName = System.getProperty("os.name").toLowerCase();
         final String osArch = System.getProperty("os.arch").toLowerCase();
         String classifier;
@@ -72,7 +78,7 @@ public abstract class BaseResolver {
         if (!destination.exists()) {
             destination.mkdirs();
         }
-        
+
         try (GzipCompressorInputStream gzipIn = new GzipCompressorInputStream(archive);
                 TarArchiveInputStream tarIn = new TarArchiveInputStream(gzipIn)) {
 
@@ -93,16 +99,16 @@ public abstract class BaseResolver {
 
                 // Create the output file with its original permissions
                 Files.createFile(outputFile.toPath());
-                
+
                 // Get the POSIX file permissions from the TarArchiveEntry
                 int mode = ((TarArchiveEntry) entry).getMode();
                 Set<PosixFilePermission> permissions = convertModeToPosixFilePermissions(mode);
                 try {
                     Files.setPosixFilePermissions(outputFile.toPath(), permissions);
-                } catch(UnsupportedOperationException e) { 
+                } catch (UnsupportedOperationException e) {
                     // ignore we are on a platform that doesn't support this
                 }
-                
+
                 try (OutputStream outputStream = new FileOutputStream(outputFile)) {
                     byte[] buffer = new byte[4096];
                     int bytesRead;
@@ -112,8 +118,8 @@ public abstract class BaseResolver {
                 }
             }
         }
-        
-        return destination.toPath().resolve(executablePath());
+
+        return destination.toPath().resolve(resolveExecutablePath());
     }
 
     static Path createDestination(String version) throws IOException {
@@ -123,7 +129,7 @@ public abstract class BaseResolver {
     static Path getLocation(String version) {
         return Path.of(System.getProperty("java.io.tmpdir")).resolve("esbuild-" + version);
     }
-    
+
     // Helper method to convert Tar mode to PosixFilePermission
     private static Set<PosixFilePermission> convertModeToPosixFilePermissions(int mode) {
         Set<PosixFilePermission> permissions = new HashSet<>(Arrays.asList(PosixFilePermission.values()));
@@ -138,7 +144,7 @@ public abstract class BaseResolver {
 
         return permissions;
     }
-    
+
     private static PosixFilePermission getPermissionForIndex(int index) {
         switch (index) {
             case 0:

--- a/src/main/java/io/mvnpm/esbuild/resolve/BundledResolver.java
+++ b/src/main/java/io/mvnpm/esbuild/resolve/BundledResolver.java
@@ -12,7 +12,7 @@ public class BundledResolver extends BaseResolver implements Resolver {
 
     @Override
     public Path resolve(String version) throws IOException {
-        final InputStream resource = getClass().getResourceAsStream("/%s-%s.tgz".formatted(determineClassifier(), version));
+        final InputStream resource = getClass().getResourceAsStream("/%s-%s.tgz".formatted(CLASSIFIER, version));
 
         if (resource != null) {
             return extract(resource, version);

--- a/src/main/java/io/mvnpm/esbuild/resolve/CacheResolver.java
+++ b/src/main/java/io/mvnpm/esbuild/resolve/CacheResolver.java
@@ -12,7 +12,7 @@ public class CacheResolver extends BaseResolver implements Resolver {
     @Override
     public Path resolve(String version) throws IOException {
         final Path path = getLocation(version);
-        final Path executable = path.resolve(executablePath());
+        final Path executable = path.resolve(EXECUTABLE_PATH);
         if (Files.isExecutable(executable)) {
             return executable;
         }

--- a/src/main/java/io/mvnpm/esbuild/resolve/DownloadResolver.java
+++ b/src/main/java/io/mvnpm/esbuild/resolve/DownloadResolver.java
@@ -1,7 +1,5 @@
 package io.mvnpm.esbuild.resolve;
 
-import org.apache.commons.text.StringSubstitutor;
-
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
@@ -10,6 +8,8 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+
+import org.apache.commons.text.StringSubstitutor;
 
 public class DownloadResolver extends BaseResolver implements Resolver {
     private static final String URL_TEMPLATE = "https://registry.npmjs.org/@esbuild/${classifier}/-/${classifier}-${version}.tgz";
@@ -22,9 +22,8 @@ public class DownloadResolver extends BaseResolver implements Resolver {
     @Override
     public Path resolve(String version) throws IOException {
         final String url = new StringSubstitutor(Map.of(
-                "classifier", determineClassifier(),
-                "version", version
-        )).replace(URL_TEMPLATE);
+                "classifier", CLASSIFIER,
+                "version", version)).replace(URL_TEMPLATE);
 
         final Path destination = createDestination(version);
         final Path tarFile = destination.resolve(FILE_NAME);

--- a/src/main/java/io/mvnpm/esbuild/util/Copy.java
+++ b/src/main/java/io/mvnpm/esbuild/util/Copy.java
@@ -1,5 +1,7 @@
 package io.mvnpm.esbuild.util;
 
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -7,8 +9,6 @@ import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 public class Copy {
 
@@ -39,7 +39,7 @@ public class Copy {
     }
 
     public static void deleteRecursive(Path source) throws IOException {
-        if (!Files.exists(source)){
+        if (!Files.exists(source)) {
             return;
         }
         try (final Stream<Path> paths = Files.walk(source)) {

--- a/src/main/java/io/mvnpm/esbuild/util/JarInspector.java
+++ b/src/main/java/io/mvnpm/esbuild/util/JarInspector.java
@@ -1,9 +1,5 @@
 package io.mvnpm.esbuild.util;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.mvnpm.esbuild.model.BundleType;
-import io.mvnpm.importmap.ImportsDataBinding;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.DirectoryStream;
@@ -20,6 +16,12 @@ import java.util.Properties;
 import java.util.Queue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.mvnpm.esbuild.model.BundleType;
+import io.mvnpm.importmap.ImportsDataBinding;
 
 public class JarInspector {
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -179,8 +181,8 @@ public class JarInspector {
 
     /**
      * Find the first match recursively
-     * 
-     * @param rootPath       starting
+     *
+     * @param rootPath starting
      * @param targetFileName file we are looking for
      * @return the Path to the found file
      */

--- a/src/main/java/io/mvnpm/esbuild/util/PackageJsonCreator.java
+++ b/src/main/java/io/mvnpm/esbuild/util/PackageJsonCreator.java
@@ -1,20 +1,22 @@
 package io.mvnpm.esbuild.util;
 
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 public class PackageJsonCreator {
     private static final ObjectMapper mapper = new ObjectMapper();
     private static final ObjectNode browser = mapper.createObjectNode();
-    
-    private PackageJsonCreator(){}
-    
+
+    private PackageJsonCreator() {
+    }
+
     public static void createPackageJson(Path root, String name, String version, String main) {
         try {
             ObjectWriter writer = mapper.writer(new DefaultPrettyPrinter());
@@ -25,18 +27,18 @@ public class PackageJsonCreator {
             throw new UncheckedIOException(ex);
         }
     }
-    
-    private static ObjectNode createNode(String name, String version, String main){
+
+    private static ObjectNode createNode(String name, String version, String main) {
         ObjectNode node = mapper.createObjectNode();
-        
+
         node.put("name", name);
         node.put("version", version);
         node.put("main", main);
         node.set("browser", browser);
-        
+
         return node;
     }
-    
+
     static {
         browser.put("fs", false);
         browser.put("path", false);

--- a/src/main/java/io/mvnpm/esbuild/util/UnZip.java
+++ b/src/main/java/io/mvnpm/esbuild/util/UnZip.java
@@ -1,6 +1,5 @@
 package io.mvnpm.esbuild.util;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/test/java/io/mvnpm/esbuild/BundlerTest.java
+++ b/src/test/java/io/mvnpm/esbuild/BundlerTest.java
@@ -1,10 +1,7 @@
 package io.mvnpm.esbuild;
 
-import io.mvnpm.esbuild.model.BundleOptions;
-import io.mvnpm.esbuild.model.BundleOptionsBuilder;
-import io.mvnpm.esbuild.model.BundleResult;
-import io.mvnpm.esbuild.model.BundleType;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,8 +11,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import io.mvnpm.esbuild.model.BundleOptions;
+import io.mvnpm.esbuild.model.BundleOptionsBuilder;
+import io.mvnpm.esbuild.model.BundleResult;
+import io.mvnpm.esbuild.model.BundleType;
 
 public class BundlerTest {
 
@@ -28,12 +29,12 @@ public class BundlerTest {
     public void shouldBundleMvnpmAndCreatePackageJson() throws URISyntaxException, IOException {
         executeTest("/mvnpm/stimulus-3.2.0.jar", BundleType.MVNPM, "application-mvnpm.js", true);
     }
-    
+
     @Test
     public void shouldBundleMvnpmWithoutPackageJson() throws URISyntaxException, IOException {
         executeTest("/mvnpm/polymer-3.5.1.jar", BundleType.MVNPM, "application-mvnpm-importmap.js", true);
     }
-    
+
     @Test
     public void shouldBundle() throws URISyntaxException, IOException {
         executeTest("/webjars/htmx.org-1.8.4.jar", BundleType.WEBJARS, "application-webjar.js", true);
@@ -65,7 +66,8 @@ public class BundlerTest {
     public void shouldResolveRelativeFolders() throws URISyntaxException, IOException {
         // given
         final Path root = new File(getClass().getResource("/path/").toURI()).toPath();
-        final BundleOptions bundleOptions = new BundleOptionsBuilder().setWorkFolder(root).addAutoEntryPoint(root,"main", List.of("foo/bar.js")).build();
+        final BundleOptions bundleOptions = new BundleOptionsBuilder().setWorkFolder(root)
+                .addAutoEntryPoint(root, "main", List.of("foo/bar.js")).build();
 
         // when
         final BundleResult result = Bundler.bundle(bundleOptions);
@@ -74,7 +76,8 @@ public class BundlerTest {
         assertTrue(result.dist().toFile().exists());
     }
 
-    private void executeTest(String jarName, BundleType type, String scriptName, boolean check) throws URISyntaxException, IOException {
+    private void executeTest(String jarName, BundleType type, String scriptName, boolean check)
+            throws URISyntaxException, IOException {
         final BundleOptions bundleOptions = getBundleOptions(jarName, type, scriptName);
         final BundleResult result = Bundler.bundle(bundleOptions);
 
@@ -87,7 +90,7 @@ public class BundlerTest {
     private BundleOptions getBundleOptions(String jarName, BundleType type, String scriptName) throws URISyntaxException {
         final File jar = new File(getClass().getResource(jarName).toURI());
         final List<Path> dependencies = Collections.singletonList(jar.toPath());
-        final Path rootDir =  new File(getClass().getResource("/").toURI()).toPath();
+        final Path rootDir = new File(getClass().getResource("/").toURI()).toPath();
         return new BundleOptionsBuilder().withDependencies(dependencies)
                 .addEntryPoint(rootDir, scriptName).withType(type).build();
     }

--- a/src/test/java/io/mvnpm/esbuild/ExecuteTest.java
+++ b/src/test/java/io/mvnpm/esbuild/ExecuteTest.java
@@ -1,14 +1,15 @@
 package io.mvnpm.esbuild;
 
-import io.mvnpm.esbuild.model.EsBuildConfig;
-import io.mvnpm.esbuild.model.ExecuteResult;
-import io.mvnpm.esbuild.resolve.ExecutableResolver;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+import io.mvnpm.esbuild.model.EsBuildConfig;
+import io.mvnpm.esbuild.model.ExecuteResult;
+import io.mvnpm.esbuild.resolve.ExecutableResolver;
 
 public class ExecuteTest {
 
@@ -16,7 +17,7 @@ public class ExecuteTest {
     public void shouldExecuteEsBuild() throws IOException {
         final EsBuildConfig esBuildConfig = new EsBuildConfig();
         esBuildConfig.setVersion(true);
-        final String defaultVersion = Bundler.getDefaultVersion();
+        final String defaultVersion = Bundler.ESBUILD_EMBEDDED_VERSION;
         final Path path = new ExecutableResolver().resolve(defaultVersion);
         final ExecuteResult executeResult = new Execute(path.toFile(), esBuildConfig).executeAndWait();
         assertEquals(defaultVersion + "\n", executeResult.output());

--- a/src/test/java/io/mvnpm/esbuild/model/AutoEntryPointTest.java
+++ b/src/test/java/io/mvnpm/esbuild/model/AutoEntryPointTest.java
@@ -1,6 +1,6 @@
 package io.mvnpm.esbuild.model;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -15,7 +15,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class AutoEntryPointTest {
 
@@ -25,7 +25,8 @@ public class AutoEntryPointTest {
         final Path workDir = Files.createTempDirectory("test");
         final Path rootDir = getRootScriptsDir();
         // when
-        final AutoEntryPoint entry = new AutoEntryPoint(rootDir, "bundle", List.of("script1.js", "script2-test.js", "sub/sub.js"));
+        final AutoEntryPoint entry = new AutoEntryPoint(rootDir, "bundle",
+                List.of("script1.js", "script2-test.js", "sub/sub.js"));
         String entryContents = readEntry(entry, workDir);
 
         // then

--- a/src/test/java/io/mvnpm/esbuild/model/EsBuildConfigTest.java
+++ b/src/test/java/io/mvnpm/esbuild/model/EsBuildConfigTest.java
@@ -1,16 +1,12 @@
 package io.mvnpm.esbuild.model;
 
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
-import java.util.Map;
-
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
 
 public class EsBuildConfigTest {
 
@@ -45,17 +41,18 @@ public class EsBuildConfigTest {
     public void shouldOutputStandardFlags() {
         // given
         final EsBuildConfig esBuildConfig = new EsBuildConfigBuilder().bundle()
-                .entryPoint(new String[]{"main.js", "bundle.js"}).outDir("/tmp").minify().build();
+                .entryPoint(new String[] { "main.js", "bundle.js" }).outDir("/tmp").minify().build();
 
         // when
         final String[] params = esBuildConfig.toParams();
 
         // then
-        assertThat(asList(params), containsInAnyOrder("--bundle", "main.js", "bundle.js", "--minify", "--format=esm", "--loader:.svg=file",
-            "--loader:.gif=file", "--loader:.css=css", "--loader:.jpg=file", "--loader:.eot=file", "--loader:.json=json",
-            "--loader:.ts=ts", "--loader:.png=file", "--loader:.ttf=file", "--loader:.woff2=file", "--loader:.jsx=jsx",
-            "--loader:.js=js", "--loader:.woff=file", "--loader:.tsx=tsx", "--outdir=/tmp", "--sourcemap",
-            "--splitting", "--entry-names=[name]-[hash]", "--asset-names=assets/[name]-[hash]"));
+        assertThat(asList(params), containsInAnyOrder("--bundle", "main.js", "bundle.js", "--minify", "--format=esm",
+                "--loader:.svg=file",
+                "--loader:.gif=file", "--loader:.css=css", "--loader:.jpg=file", "--loader:.eot=file", "--loader:.json=json",
+                "--loader:.ts=ts", "--loader:.png=file", "--loader:.ttf=file", "--loader:.woff2=file", "--loader:.jsx=jsx",
+                "--loader:.js=js", "--loader:.woff=file", "--loader:.tsx=tsx", "--outdir=/tmp", "--sourcemap",
+                "--splitting", "--entry-names=[name]-[hash]", "--asset-names=assets/[name]-[hash]"));
     }
 
     @Test

--- a/src/test/java/io/mvnpm/esbuild/resolve/BundleResolverTest.java
+++ b/src/test/java/io/mvnpm/esbuild/resolve/BundleResolverTest.java
@@ -1,17 +1,20 @@
 package io.mvnpm.esbuild.resolve;
 
-import io.mvnpm.esbuild.Bundler;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.mvnpm.esbuild.Bundler;
 
 public class BundleResolverTest extends BundleTester {
 
-    public static final Resolver THROWING_RESOLVER = version -> { throw new RuntimeException("Should not call this"); };
+    public static final Resolver THROWING_RESOLVER = version -> {
+        throw new RuntimeException("Should not call this");
+    };
 
     @BeforeAll
     public static void cleanUp() throws IOException {
@@ -21,7 +24,7 @@ public class BundleResolverTest extends BundleTester {
     @Test
     public void resolve() throws IOException {
         // when
-        final Path resolve = new BundledResolver(THROWING_RESOLVER).resolve(Bundler.getDefaultVersion());
+        final Path resolve = new BundledResolver(THROWING_RESOLVER).resolve(Bundler.ESBUILD_EMBEDDED_VERSION);
 
         // then
         assertTrue(resolve.toFile().exists());

--- a/src/test/java/io/mvnpm/esbuild/resolve/BundleTester.java
+++ b/src/test/java/io/mvnpm/esbuild/resolve/BundleTester.java
@@ -1,18 +1,17 @@
 package io.mvnpm.esbuild.resolve;
 
+import java.io.IOException;
+
 import io.mvnpm.esbuild.Bundler;
 import io.mvnpm.esbuild.util.Copy;
 
-import java.io.IOException;
-
 public abstract class BundleTester {
-
 
     public static void cleanUp(String version) throws IOException {
         Copy.deleteRecursive(BaseResolver.getLocation(version));
     }
 
     public static void cleanUpDefault() throws IOException {
-        cleanUp(Bundler.getDefaultVersion());
+        cleanUp(Bundler.ESBUILD_EMBEDDED_VERSION);
     }
 }

--- a/src/test/java/io/mvnpm/esbuild/resolve/CacheResolverTest.java
+++ b/src/test/java/io/mvnpm/esbuild/resolve/CacheResolverTest.java
@@ -1,23 +1,18 @@
 package io.mvnpm.esbuild.resolve;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.util.Set;
-
-import static io.mvnpm.esbuild.resolve.BaseResolver.executablePath;
+import static io.mvnpm.esbuild.resolve.BaseResolver.EXECUTABLE_PATH;
 import static io.mvnpm.esbuild.resolve.BundleResolverTest.THROWING_RESOLVER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CacheResolverTest extends BundleTester {
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+public class CacheResolverTest extends BundleTester {
 
     @AfterAll
     public static void cleanUp() throws IOException {
@@ -57,7 +52,7 @@ public class CacheResolverTest extends BundleTester {
 
     private Path createEsBuildBinary(String version) throws IOException {
         final Path destination = BaseResolver.createDestination(version);
-        final Path exec = destination.resolve(executablePath());
+        final Path exec = destination.resolve(EXECUTABLE_PATH);
         Files.createDirectories(exec.getParent());
         Files.writeString(exec, "hello");
         exec.toFile().setExecutable(true, true);

--- a/src/test/java/io/mvnpm/esbuild/resolve/DownloadResolverTest.java
+++ b/src/test/java/io/mvnpm/esbuild/resolve/DownloadResolverTest.java
@@ -1,14 +1,15 @@
 package io.mvnpm.esbuild.resolve;
 
-import io.mvnpm.esbuild.Bundler;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import static io.mvnpm.esbuild.resolve.BundleResolverTest.THROWING_RESOLVER;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static io.mvnpm.esbuild.resolve.BundleResolverTest.THROWING_RESOLVER;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.mvnpm.esbuild.Bundler;
 
 public class DownloadResolverTest extends BundleTester {
 
@@ -20,7 +21,7 @@ public class DownloadResolverTest extends BundleTester {
     @Test
     public void download() throws IOException {
         // when
-        final Path path = new DownloadResolver(THROWING_RESOLVER).resolve(Bundler.getDefaultVersion());
+        final Path path = new DownloadResolver(THROWING_RESOLVER).resolve(Bundler.ESBUILD_EMBEDDED_VERSION);
 
         // then
         assertTrue(path.toFile().exists());

--- a/src/test/java/io/mvnpm/esbuild/util/PackageJsonTest.java
+++ b/src/test/java/io/mvnpm/esbuild/util/PackageJsonTest.java
@@ -1,7 +1,6 @@
 package io.mvnpm.esbuild.util;
 
-import io.mvnpm.esbuild.model.BundleType;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,7 +9,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
+import io.mvnpm.esbuild.model.BundleType;
 
 class PackageJsonTest {
 
@@ -31,9 +32,9 @@ class PackageJsonTest {
         UnZip.unzip(new File(getClass().getResource("/mvnpm/vaadin-webcomponents-24.1.6.jar").toURI()).toPath(), temp);
         final Map<String, Path> packageNameAndRoot = JarInspector.findPackageNameAndRoot(temp, BundleType.MVNPM);
         assertFalse(packageNameAndRoot.isEmpty());
-        assertTrue(packageNameAndRoot.size()>1);
+        assertTrue(packageNameAndRoot.size() > 1);
     }
-    
+
     @Test
     void findPackageWebjarsTest() throws URISyntaxException, IOException {
         final Path temp = Files.createTempDirectory("findPackageWebjarsTest");

--- a/src/test/java/io/mvnpm/esbuild/util/UnZipTest.java
+++ b/src/test/java/io/mvnpm/esbuild/util/UnZipTest.java
@@ -1,6 +1,6 @@
 package io.mvnpm.esbuild.util;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.io.File;
 import java.io.IOException;
@@ -8,7 +8,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import org.junit.jupiter.api.Test;
 
 public class UnZipTest {
 
@@ -23,7 +23,7 @@ public class UnZipTest {
 
         // then
         final String[] list = junit.toFile().list();
-        assertArrayEquals(new String[]{"META-INF"}, list);
+        assertArrayEquals(new String[] { "META-INF" }, list);
 
     }
 }


### PR DESCRIPTION
- Add formatter and import sort on build
- Avoid resolving `EXECUTABLE_PATH` and `CLASSIFIER` on every calls.
- Add checks on CI

Fixes #57 