### PR TITLE
Introduce WebDepsInstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ esbuild-java
 [![Maven Central](https://img.shields.io/maven-central/v/io.mvnpm/esbuild-java.svg?label=Maven%20Central)](https://search.maven.org/artifact/io.mvnpm/esbuild-java)
 [![Apache License, Version 2.0, January 2004](https://img.shields.io/github/license/apache/maven.svg?label=License)](https://www.apache.org/licenses/LICENSE-2.0)
 
-This is a small warpper around the esbuild executable, so that you can invoke it from java.
+This is a small wrapper around the esbuild executable, so that you can invoke it from java.
 
 ```java
 // create the command line parameters 
@@ -30,9 +30,9 @@ Additionally, it has a utility to bundle a javascript file with webjar or mvnpm 
 
 ```java
 final BundleOptions bundleOptions = new BundleOptionsBuilder().withDependencies(dependencies)
-        .withEntry(entry).withType(type).build();
-final Path path = Bundler.bundle(bundleOptions);
+        .withEntry(entry).build();
+final Path path = Bundler.bundle(bundleOptions, true);
 ```
 
-Dependencies are a list of either webjar or mvnpm bundles, type is the type of the bundles and entry is the javascript.
+Dependencies are a list of either webjar or mvnpm jars.
 Returned is the folder that contains the result of the transformation.

--- a/pom.xml
+++ b/pom.xml
@@ -72,11 +72,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
-    </dependency>
-
-    <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/src/main/java/io/mvnpm/esbuild/Bundler.java
+++ b/src/main/java/io/mvnpm/esbuild/Bundler.java
@@ -42,12 +42,15 @@ public class Bundler {
      * Use esbuild to bundle either webjar or mvnpm dependencies into a bundle.
      *
      * @param bundleOptions options to do the bundling with
+     * @param install if the dependencies should be installed before bundling
      * @return the folder that has the result of the transformation
      * @throws IOException when something could not be written
      */
-    public static BundleResult bundle(BundleOptions bundleOptions) throws IOException {
+    public static BundleResult bundle(BundleOptions bundleOptions, boolean install) throws IOException {
         final Path workDir = getWorkDir(bundleOptions);
-        install(workDir, bundleOptions);
+        if (install) {
+            install(workDir, bundleOptions);
+        }
         final Path dist = workDir.resolve(DIST);
         final EsBuildConfig esBuildConfig = createBundle(bundleOptions, workDir, dist);
 
@@ -87,11 +90,11 @@ public class Bundler {
                 : Files.createTempDirectory("bundle");
     }
 
-    public static void install(Path workDir, BundleOptions bundleOptions) throws IOException {
+    public static boolean install(Path workDir, BundleOptions bundleOptions) throws IOException {
         final Path nodeModulesDir = bundleOptions.getNodeModulesDir() == null
                 ? workDir.resolve(BundleOptions.NODE_MODULES)
                 : bundleOptions.getNodeModulesDir();
-        WebDepsInstaller.install(nodeModulesDir, bundleOptions.getDependencies());
+        return WebDepsInstaller.install(nodeModulesDir, bundleOptions.getDependencies());
     }
 
     public static void clearDependencies(Path nodeModulesDir) throws IOException {

--- a/src/main/java/io/mvnpm/esbuild/Watch.java
+++ b/src/main/java/io/mvnpm/esbuild/Watch.java
@@ -1,6 +1,6 @@
 package io.mvnpm.esbuild;
 
-import static io.mvnpm.esbuild.util.Copy.copyEntries;
+import static io.mvnpm.esbuild.util.PathUtils.copyEntries;
 
 import java.nio.file.Path;
 import java.util.List;

--- a/src/main/java/io/mvnpm/esbuild/install/MvnpmInfo.java
+++ b/src/main/java/io/mvnpm/esbuild/install/MvnpmInfo.java
@@ -1,0 +1,11 @@
+package io.mvnpm.esbuild.install;
+
+import java.util.List;
+import java.util.Set;
+
+public record MvnpmInfo(Set<InstalledDependency> installed) {
+
+    public record InstalledDependency(String id, List<String> dirs) {
+
+    }
+}

--- a/src/main/java/io/mvnpm/esbuild/install/WebDepsInstaller.java
+++ b/src/main/java/io/mvnpm/esbuild/install/WebDepsInstaller.java
@@ -1,0 +1,121 @@
+package io.mvnpm.esbuild.install;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.mvnpm.esbuild.model.WebDependency;
+import io.mvnpm.esbuild.util.JarInspector;
+import io.mvnpm.esbuild.util.PathUtils;
+import io.mvnpm.esbuild.util.UnZip;
+
+public final class WebDepsInstaller {
+
+    private static final Logger logger = Logger.getLogger(WebDepsInstaller.class.getName());
+
+    private static final String MVNPM_DIR = ".mvnpm";
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public static void install(Path nodeModulesDir, List<WebDependency> dependencies) throws IOException {
+
+        final Path mvnpmInfoFile = getMvnpmInfoPath(nodeModulesDir);
+        final MvnpmInfo mvnpmInfo = readMvnpmInfo(mvnpmInfoFile);
+        if (mvnpmInfo.installed().isEmpty()) {
+            // Make sure it is clean
+            PathUtils.deleteRecursive(nodeModulesDir);
+        }
+        if (!Files.exists(nodeModulesDir)) {
+            Files.createDirectories(nodeModulesDir);
+        }
+        final Path tmp = nodeModulesDir.resolve(MVNPM_DIR).resolve("tmp");
+        final Set<MvnpmInfo.InstalledDependency> installed = new HashSet<>();
+        for (WebDependency dep : dependencies) {
+            final Optional<MvnpmInfo.InstalledDependency> alreadyInstalled = mvnpmInfo.installed().stream()
+                    .filter(i -> i.id().equals(dep.id())).findFirst();
+            if (alreadyInstalled.isPresent()) {
+                logger.log(Level.FINE, "skipping package as it already exists ''{0}''", dep.id());
+                installed.add(alreadyInstalled.get());
+                continue;
+            }
+            final Path extractDir = tmp.resolve(dep.id());
+            PathUtils.deleteRecursive(extractDir);
+            UnZip.unzip(dep.path(), extractDir);
+            final Map<String, Path> packageNameAndRoot = JarInspector.findPackageNameAndRoot(extractDir, dep.type());
+            List<String> dirs = new ArrayList<>();
+            if (!packageNameAndRoot.isEmpty()) {
+                for (Map.Entry<String, Path> nameAndRoot : packageNameAndRoot.entrySet()) {
+                    final String packageName = nameAndRoot.getKey();
+                    final Path source = nameAndRoot.getValue();
+                    final Path target = nodeModulesDir.resolve(packageName);
+                    dirs.add(packageName);
+                    PathUtils.deleteRecursive(target);
+                    Files.createDirectories(target.getParent());
+                    Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+                    logger.log(Level.FINE, "installed package ''{0}''", packageName);
+                }
+                installed.add(new MvnpmInfo.InstalledDependency(dep.id(), dirs));
+                logger.log(Level.FINE, "installed dep ''{0}'' (''{1}'')", new Object[] { dep.path(), dep.id() });
+            } else {
+                logger.log(Level.WARNING, "package.json not found in dep: ''{0}'' (''{1}'')",
+                        new Object[] { dep.path(), dep.id() });
+            }
+        }
+        PathUtils.deleteRecursive(tmp);
+        for (MvnpmInfo.InstalledDependency installedDependency : mvnpmInfo.installed()) {
+            if (!installed.contains(installedDependency)) {
+                logger.log(Level.FINE, "removing package as it is not needed anymore ''{0}''", installedDependency.id());
+                for (String dir : installedDependency.dirs()) {
+                    PathUtils.deleteRecursive(nodeModulesDir.resolve(dir));
+                }
+            }
+        }
+        final MvnpmInfo newMvnpmInfo = new MvnpmInfo(installed);
+        WebDepsInstaller.writeMvnpmInfo(mvnpmInfoFile, newMvnpmInfo);
+    }
+
+    public static Path getMvnpmInfoPath(Path nodeModulesDir) {
+        return nodeModulesDir.resolve(MVNPM_DIR).resolve("mvnpm.json");
+    }
+
+    public static MvnpmInfo readMvnpmInfo(Path path) {
+        if (!Files.exists(path)) {
+            return new MvnpmInfo(Set.of());
+        }
+        try (InputStream s = Files.newInputStream(path)) {
+            return mapper.readValue(s, MvnpmInfo.class);
+        } catch (IOException e) {
+            try {
+                Files.deleteIfExists(path);
+            } catch (IOException ex) {
+                throw new UncheckedIOException(ex);
+            }
+            return new MvnpmInfo(Set.of());
+        }
+    }
+
+    public static void writeMvnpmInfo(Path path, MvnpmInfo root) {
+        try {
+            Files.deleteIfExists(path);
+            Files.createDirectories(path.getParent());
+            mapper.writer(new DefaultPrettyPrinter()).writeValue(path.toFile(), root);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+}

--- a/src/main/java/io/mvnpm/esbuild/model/AutoEntryPoint.java
+++ b/src/main/java/io/mvnpm/esbuild/model/AutoEntryPoint.java
@@ -1,6 +1,6 @@
 package io.mvnpm.esbuild.model;
 
-import static io.mvnpm.esbuild.util.Copy.copyEntries;
+import static io.mvnpm.esbuild.util.PathUtils.copyEntries;
 
 import java.io.IOException;
 import java.io.StringWriter;

--- a/src/main/java/io/mvnpm/esbuild/model/BundleOptions.java
+++ b/src/main/java/io/mvnpm/esbuild/model/BundleOptions.java
@@ -6,15 +6,17 @@ import java.util.List;
 
 public class BundleOptions {
 
+    public static final String NODE_MODULES = "node_modules";
+
     private List<EntryPoint> entries;
 
-    private List<Path> dependencies = new ArrayList<>();
-
-    private BundleType type;
+    private List<WebDependency> dependencies = new ArrayList<>();
 
     private EsBuildConfig esBuildConfig;
 
     private Path workDir;
+
+    private Path nodeModulesDir;
 
     public List<EntryPoint> getEntries() {
         return entries;
@@ -24,20 +26,12 @@ public class BundleOptions {
         this.entries = entries;
     }
 
-    public List<Path> getDependencies() {
+    public List<WebDependency> getDependencies() {
         return dependencies;
     }
 
-    public void setDependencies(List<Path> dependencies) {
+    public void setDependencies(List<WebDependency> dependencies) {
         this.dependencies = dependencies;
-    }
-
-    public BundleType getType() {
-        return type;
-    }
-
-    public void setType(BundleType type) {
-        this.type = type;
     }
 
     public EsBuildConfig getEsBuildConfig() {
@@ -58,5 +52,14 @@ public class BundleOptions {
 
     public void setWorkDir(Path workDir) {
         this.workDir = workDir;
+    }
+
+    public Path getNodeModulesDir() {
+        return nodeModulesDir;
+    }
+
+    public BundleOptions setNodeModulesDir(Path nodeModulesDir) {
+        this.nodeModulesDir = nodeModulesDir;
+        return this;
     }
 }

--- a/src/main/java/io/mvnpm/esbuild/model/BundleOptionsBuilder.java
+++ b/src/main/java/io/mvnpm/esbuild/model/BundleOptionsBuilder.java
@@ -32,18 +32,23 @@ public class BundleOptionsBuilder {
         return this;
     }
 
-    public BundleOptionsBuilder setWorkFolder(Path workFolder) {
-        this.options.setWorkDir(workFolder);
+    public BundleOptionsBuilder withNodeModulesDir(Path nodeModulesDir) {
+        this.options.setNodeModulesDir(nodeModulesDir);
         return this;
     }
 
-    public BundleOptionsBuilder withDependencies(List<Path> dependencies) {
+    public BundleOptionsBuilder setWorkDir(Path workDir) {
+        this.options.setWorkDir(workDir);
+        return this;
+    }
+
+    public BundleOptionsBuilder withDependencies(List<Path> dependencies, WebDependency.WebDependencyType type) {
+        this.options.setDependencies(dependencies.stream().map(d -> WebDependency.of(d, type)).toList());
+        return this;
+    }
+
+    public BundleOptionsBuilder withDependencies(List<WebDependency> dependencies) {
         this.options.setDependencies(dependencies);
-        return this;
-    }
-
-    public BundleOptionsBuilder withType(BundleType type) {
-        this.options.setType(type);
         return this;
     }
 

--- a/src/main/java/io/mvnpm/esbuild/model/BundleOptionsBuilder.java
+++ b/src/main/java/io/mvnpm/esbuild/model/BundleOptionsBuilder.java
@@ -37,7 +37,7 @@ public class BundleOptionsBuilder {
         return this;
     }
 
-    public BundleOptionsBuilder setWorkDir(Path workDir) {
+    public BundleOptionsBuilder withWorkDir(Path workDir) {
         this.options.setWorkDir(workDir);
         return this;
     }

--- a/src/main/java/io/mvnpm/esbuild/model/BundleType.java
+++ b/src/main/java/io/mvnpm/esbuild/model/BundleType.java
@@ -1,6 +1,0 @@
-package io.mvnpm.esbuild.model;
-
-public enum BundleType {
-    WEBJARS,
-    MVNPM
-}

--- a/src/main/java/io/mvnpm/esbuild/model/FileEntryPoint.java
+++ b/src/main/java/io/mvnpm/esbuild/model/FileEntryPoint.java
@@ -1,6 +1,6 @@
 package io.mvnpm.esbuild.model;
 
-import static io.mvnpm.esbuild.util.Copy.copyEntries;
+import static io.mvnpm.esbuild.util.PathUtils.copyEntries;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;

--- a/src/main/java/io/mvnpm/esbuild/model/WebDependency.java
+++ b/src/main/java/io/mvnpm/esbuild/model/WebDependency.java
@@ -1,6 +1,8 @@
 package io.mvnpm.esbuild.model;
 
 import java.nio.file.Path;
+import java.util.Optional;
+import java.util.function.Predicate;
 
 public record WebDependency(String id, Path path, WebDependencyType type) {
 
@@ -14,7 +16,30 @@ public record WebDependency(String id, Path path, WebDependencyType type) {
     }
 
     public enum WebDependencyType {
-        WEBJARS,
-        MVNPM
+        WEBJARS(s -> s.startsWith("org.webjars.npm")),
+        MVNPM(s -> s.startsWith("org.mvnpm"));
+
+        private final Predicate<String> gavMatcher;
+
+        WebDependencyType(Predicate<String> gavMatcher) {
+            this.gavMatcher = gavMatcher;
+        }
+
+        public boolean matches(String gav) {
+            return this.gavMatcher.test(gav);
+        }
+
+        public static boolean anyMatch(String gav) {
+            return resolveType(gav).isPresent();
+        }
+
+        public static Optional<WebDependencyType> resolveType(String gav) {
+            for (WebDependencyType value : values()) {
+                if (value.matches(gav)) {
+                    return Optional.of(value);
+                }
+            }
+            return Optional.empty();
+        }
     }
 }

--- a/src/main/java/io/mvnpm/esbuild/model/WebDependency.java
+++ b/src/main/java/io/mvnpm/esbuild/model/WebDependency.java
@@ -1,0 +1,20 @@
+package io.mvnpm.esbuild.model;
+
+import java.nio.file.Path;
+
+public record WebDependency(String id, Path path, WebDependencyType type) {
+
+    public static WebDependency of(String id, Path path, WebDependencyType type) {
+        return new WebDependency(id, path, type);
+    }
+
+    public static WebDependency of(Path path, WebDependencyType type) {
+        final String fileName = path.getFileName().toString();
+        return new WebDependency(fileName.substring(0, fileName.lastIndexOf(".")), path, type);
+    }
+
+    public enum WebDependencyType {
+        WEBJARS,
+        MVNPM
+    }
+}

--- a/src/main/java/io/mvnpm/esbuild/resolve/DownloadResolver.java
+++ b/src/main/java/io/mvnpm/esbuild/resolve/DownloadResolver.java
@@ -7,12 +7,9 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
-
-import org.apache.commons.text.StringSubstitutor;
 
 public class DownloadResolver extends BaseResolver implements Resolver {
-    private static final String URL_TEMPLATE = "https://registry.npmjs.org/@esbuild/${classifier}/-/${classifier}-${version}.tgz";
+    private static final String URL_TEMPLATE = "https://registry.npmjs.org/@esbuild/%1$s/-/%1$s-%2$s.tgz";
     private static final String FILE_NAME = "esbuild.tgz";
 
     public DownloadResolver(Resolver resolver) {
@@ -21,9 +18,7 @@ public class DownloadResolver extends BaseResolver implements Resolver {
 
     @Override
     public Path resolve(String version) throws IOException {
-        final String url = new StringSubstitutor(Map.of(
-                "classifier", CLASSIFIER,
-                "version", version)).replace(URL_TEMPLATE);
+        final String url = URL_TEMPLATE.formatted(CLASSIFIER, version);
 
         final Path destination = createDestination(version);
         final Path tarFile = destination.resolve(FILE_NAME);

--- a/src/main/java/io/mvnpm/esbuild/util/JarInspector.java
+++ b/src/main/java/io/mvnpm/esbuild/util/JarInspector.java
@@ -33,7 +33,7 @@ public class JarInspector {
     private static final String MAVEN_ROOT = "META-INF/maven";
 
     private static final Map<WebDependency.WebDependencyType, List<String>> PACKAGE_DIRS = Map.of(
-            WebDependency.WebDependencyType.MVNPM, List.of("META-INF/resources/_static", "package"),
+            WebDependency.WebDependencyType.MVNPM, List.of("META-INF/resources/_static", "package", ""),
             WebDependency.WebDependencyType.WEBJARS, List.of("META-INF/resources/webjars"));
     private static final List<String> MULTIPLE_GROUP_IDS = List.of("org.mvnpm.at.mvnpm"); // Group Ids that can contain
                                                                                           // multiple package.jsons

--- a/src/main/java/io/mvnpm/esbuild/util/JarInspector.java
+++ b/src/main/java/io/mvnpm/esbuild/util/JarInspector.java
@@ -20,7 +20,7 @@ import java.util.logging.Logger;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.mvnpm.esbuild.model.BundleType;
+import io.mvnpm.esbuild.model.WebDependency;
 import io.mvnpm.importmap.ImportsDataBinding;
 
 public class JarInspector {
@@ -32,15 +32,15 @@ public class JarInspector {
     public static final String POM_PROPERTIES = "pom.properties";
     private static final String MAVEN_ROOT = "META-INF/maven";
 
-    private static final Map<BundleType, List<String>> PACKAGE_DIRS = Map.of(
-            BundleType.MVNPM, List.of("META-INF/resources/_static", "package"),
-            BundleType.WEBJARS, List.of("META-INF/resources/webjars"));
+    private static final Map<WebDependency.WebDependencyType, List<String>> PACKAGE_DIRS = Map.of(
+            WebDependency.WebDependencyType.MVNPM, List.of("META-INF/resources/_static", "package"),
+            WebDependency.WebDependencyType.WEBJARS, List.of("META-INF/resources/webjars"));
     private static final List<String> MULTIPLE_GROUP_IDS = List.of("org.mvnpm.at.mvnpm"); // Group Ids that can contain
                                                                                           // multiple package.jsons
                                                                                           // TODO: Allow this to be
                                                                                           // configured
 
-    public static Map<String, Path> findPackageNameAndRoot(Path extractDir, BundleType type) {
+    public static Map<String, Path> findPackageNameAndRoot(Path extractDir, WebDependency.WebDependencyType type) {
 
         Path dir = getPackageRootPath(extractDir, type);
 
@@ -56,14 +56,14 @@ public class JarInspector {
         Map<String, Path> found = findPackageNameAndRootWithPackage(dir, shouldDoMultiple);
 
         // If this is mvnpm and we could not find package.json we can try another way
-        if (found.isEmpty() && type.equals(BundleType.MVNPM)) {
+        if (found.isEmpty() && type.equals(WebDependency.WebDependencyType.MVNPM)) {
             found = findPackageNameAndRootWithImportMap(extractDir, properties);
         }
 
         return found;
     }
 
-    private static Path getPackageRootPath(Path extractDir, BundleType type) {
+    private static Path getPackageRootPath(Path extractDir, WebDependency.WebDependencyType type) {
         if (!PACKAGE_DIRS.containsKey(type)) {
             throw new RuntimeException("Invalid BundleType: " + type);
         }
@@ -76,10 +76,10 @@ public class JarInspector {
         return null;
     }
 
-    private static Properties getProperties(Path extractDir, BundleType type) {
+    private static Properties getProperties(Path extractDir, WebDependency.WebDependencyType type) {
         Properties properties = new Properties();
 
-        if (type.equals(BundleType.MVNPM)) { // Only mvnpm support composite
+        if (type.equals(WebDependency.WebDependencyType.MVNPM)) { // Only mvnpm support composite
             properties = getPomProperties(extractDir);
         }
 

--- a/src/main/java/io/mvnpm/esbuild/util/PathUtils.java
+++ b/src/main/java/io/mvnpm/esbuild/util/PathUtils.java
@@ -10,7 +10,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
 
-public class Copy {
+public class PathUtils {
 
     public static void copyEntries(Path rootDir, List<String> entries, Path targetDir) {
         for (String entry : entries) {

--- a/src/test/java/io/mvnpm/esbuild/BundlerTest.java
+++ b/src/test/java/io/mvnpm/esbuild/BundlerTest.java
@@ -16,39 +16,40 @@ import org.junit.jupiter.api.Test;
 import io.mvnpm.esbuild.model.BundleOptions;
 import io.mvnpm.esbuild.model.BundleOptionsBuilder;
 import io.mvnpm.esbuild.model.BundleResult;
-import io.mvnpm.esbuild.model.BundleType;
+import io.mvnpm.esbuild.model.WebDependency.WebDependencyType;
 
 public class BundlerTest {
 
     @Test
     public void shouldBundleMvnpm() throws URISyntaxException, IOException {
-        executeTest("/mvnpm/stimulus-3.2.1.jar", BundleType.MVNPM, "application-mvnpm.js", true);
+        executeTest("/mvnpm/stimulus-3.2.1.jar", WebDependencyType.MVNPM, "application-mvnpm.js", true);
     }
 
     @Test
     public void shouldBundleMvnpmSources() throws URISyntaxException, IOException {
-        executeTest("/mvnpm/moment-2.29.4-sources.jar", BundleType.MVNPM, "application-mvnpm.ts", true);
+        executeTest("/mvnpm/moment-2.29.4-sources.jar", WebDependencyType.MVNPM, "application-mvnpm.ts", true);
     }
 
     @Test
     public void shouldBundleMvnpmAndCreatePackageJson() throws URISyntaxException, IOException {
-        executeTest("/mvnpm/stimulus-3.2.0.jar", BundleType.MVNPM, "application-mvnpm.js", true);
+        executeTest("/mvnpm/stimulus-3.2.0.jar", WebDependencyType.MVNPM, "application-mvnpm.js", true);
     }
 
     @Test
     public void shouldBundleMvnpmWithoutPackageJson() throws URISyntaxException, IOException {
-        executeTest("/mvnpm/polymer-3.5.1.jar", BundleType.MVNPM, "application-mvnpm-importmap.js", true);
+        executeTest("/mvnpm/polymer-3.5.1.jar", WebDependencyType.MVNPM, "application-mvnpm-importmap.js", true);
     }
 
     @Test
     public void shouldBundle() throws URISyntaxException, IOException {
-        executeTest("/webjars/htmx.org-1.8.4.jar", BundleType.WEBJARS, "application-webjar.js", true);
+        executeTest("/webjars/htmx.org-1.8.4.jar", WebDependencyType.WEBJARS, "application-webjar.js", true);
     }
 
     @Test
     public void shouldWatch() throws URISyntaxException, IOException, InterruptedException {
         // given
-        final BundleOptions options = getBundleOptions("/mvnpm/stimulus-3.2.1.jar", BundleType.MVNPM, "application-mvnpm.js");
+        final BundleOptions options = getBundleOptions("/mvnpm/stimulus-3.2.1.jar", WebDependencyType.MVNPM,
+                "application-mvnpm.js");
 
         // when
         AtomicBoolean isCalled = new AtomicBoolean(false);
@@ -63,7 +64,7 @@ public class BundlerTest {
     @Test
     public void shouldThrowException() {
         assertThrows(BundleException.class, () -> {
-            executeTest("/mvnpm/stimulus-3.2.1.jar", BundleType.MVNPM, "application-error.js", false);
+            executeTest("/mvnpm/stimulus-3.2.1.jar", WebDependencyType.MVNPM, "application-error.js", false);
         });
     }
 
@@ -71,7 +72,7 @@ public class BundlerTest {
     public void shouldResolveRelativeFolders() throws URISyntaxException, IOException {
         // given
         final Path root = new File(getClass().getResource("/path/").toURI()).toPath();
-        final BundleOptions bundleOptions = new BundleOptionsBuilder().setWorkFolder(root)
+        final BundleOptions bundleOptions = new BundleOptionsBuilder().setWorkDir(root)
                 .addAutoEntryPoint(root, "main", List.of("foo/bar.js")).build();
 
         // when
@@ -81,7 +82,7 @@ public class BundlerTest {
         assertTrue(result.dist().toFile().exists());
     }
 
-    private void executeTest(String jarName, BundleType type, String scriptName, boolean check)
+    private void executeTest(String jarName, WebDependencyType type, String scriptName, boolean check)
             throws URISyntaxException, IOException {
         final BundleOptions bundleOptions = getBundleOptions(jarName, type, scriptName);
         final BundleResult result = Bundler.bundle(bundleOptions);
@@ -92,12 +93,13 @@ public class BundlerTest {
 
     }
 
-    private BundleOptions getBundleOptions(String jarName, BundleType type, String scriptName) throws URISyntaxException {
+    private BundleOptions getBundleOptions(String jarName, WebDependencyType type, String scriptName)
+            throws URISyntaxException {
         final File jar = new File(getClass().getResource(jarName).toURI());
         final List<Path> dependencies = Collections.singletonList(jar.toPath());
         final Path rootDir = new File(getClass().getResource("/").toURI()).toPath();
-        return new BundleOptionsBuilder().withDependencies(dependencies)
-                .addEntryPoint(rootDir, scriptName).withType(type).build();
+        return new BundleOptionsBuilder().withDependencies(dependencies, type)
+                .addEntryPoint(rootDir, scriptName).build();
     }
 
 }

--- a/src/test/java/io/mvnpm/esbuild/BundlerTest.java
+++ b/src/test/java/io/mvnpm/esbuild/BundlerTest.java
@@ -72,11 +72,11 @@ public class BundlerTest {
     public void shouldResolveRelativeFolders() throws URISyntaxException, IOException {
         // given
         final Path root = new File(getClass().getResource("/path/").toURI()).toPath();
-        final BundleOptions bundleOptions = new BundleOptionsBuilder().setWorkDir(root)
+        final BundleOptions bundleOptions = new BundleOptionsBuilder().withWorkDir(root)
                 .addAutoEntryPoint(root, "main", List.of("foo/bar.js")).build();
 
         // when
-        final BundleResult result = Bundler.bundle(bundleOptions);
+        final BundleResult result = Bundler.bundle(bundleOptions, true);
 
         // then
         assertTrue(result.dist().toFile().exists());
@@ -85,7 +85,7 @@ public class BundlerTest {
     private void executeTest(String jarName, WebDependencyType type, String scriptName, boolean check)
             throws URISyntaxException, IOException {
         final BundleOptions bundleOptions = getBundleOptions(jarName, type, scriptName);
-        final BundleResult result = Bundler.bundle(bundleOptions);
+        final BundleResult result = Bundler.bundle(bundleOptions, true);
 
         if (check) {
             assertTrue(result.dist().toFile().exists());

--- a/src/test/java/io/mvnpm/esbuild/install/WebDepsInstallerTest.java
+++ b/src/test/java/io/mvnpm/esbuild/install/WebDepsInstallerTest.java
@@ -1,0 +1,100 @@
+package io.mvnpm.esbuild.install;
+
+import static io.mvnpm.esbuild.install.WebDepsInstaller.getMvnpmInfoPath;
+import static io.mvnpm.esbuild.install.WebDepsInstaller.install;
+import static io.mvnpm.esbuild.install.WebDepsInstaller.readMvnpmInfo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.mvnpm.esbuild.model.WebDependency;
+
+public class WebDepsInstallerTest {
+
+    @Test
+    void testInstall() throws IOException {
+        Path tempDir = Files.createTempDirectory("testInstall");
+        install(tempDir, getWebDependencies(List.of("/mvnpm/stimulus-3.2.1.jar", "/mvnpm/hooks-0.4.9.jar")));
+        final MvnpmInfo mvnpmInfo = readMvnpmInfo(getMvnpmInfoPath(tempDir));
+        assertEquals(2, mvnpmInfo.installed().size());
+        assertEquals(mvnpmInfo.installed(),
+                Set.of(new MvnpmInfo.InstalledDependency("stimulus-3.2.1", List.of("@hotwired/stimulus")),
+                        new MvnpmInfo.InstalledDependency("hooks-0.4.9", List.of("@restart/hooks"))));
+    }
+
+    @Test
+    void testReInstall() throws IOException {
+        Path tempDir = Files.createTempDirectory("testInstall");
+        install(tempDir, getWebDependencies(List.of("/mvnpm/stimulus-3.2.1.jar", "/mvnpm/hooks-0.4.9.jar")));
+        install(tempDir, getWebDependencies(List.of("/mvnpm/stimulus-3.2.1.jar", "/mvnpm/hooks-0.4.9.jar")));
+        final MvnpmInfo mvnpmInfo = readMvnpmInfo(getMvnpmInfoPath(tempDir));
+        assertEquals(2, mvnpmInfo.installed().size());
+        assertEquals(mvnpmInfo.installed(),
+                Set.of(new MvnpmInfo.InstalledDependency("stimulus-3.2.1", List.of("@hotwired/stimulus")),
+                        new MvnpmInfo.InstalledDependency("hooks-0.4.9", List.of("@restart/hooks"))));
+    }
+
+    @Test
+    void testInstallWithNewDeps() throws IOException {
+        Path tempDir = Files.createTempDirectory("testInstall");
+        install(tempDir, getWebDependencies(List.of("/mvnpm/stimulus-3.2.1.jar", "/mvnpm/hooks-0.4.9.jar")));
+        install(tempDir, getWebDependencies(List.of("/mvnpm/react-bootstrap-2.7.4.jar", "/mvnpm/hooks-0.4.9.jar")));
+        final MvnpmInfo mvnpmInfo = readMvnpmInfo(getMvnpmInfoPath(tempDir));
+        assertEquals(2, mvnpmInfo.installed().size());
+        assertEquals(mvnpmInfo.installed(),
+                Set.of(new MvnpmInfo.InstalledDependency("react-bootstrap-2.7.4", List.of("react-bootstrap")),
+                        new MvnpmInfo.InstalledDependency("hooks-0.4.9", List.of("@restart/hooks"))));
+        assertFalse(Files.exists(tempDir.resolve("@hotwired/stimulus")));
+        install(tempDir, getWebDependencies(List.of("/mvnpm/react-bootstrap-2.7.4.jar", "/mvnpm/hooks-0.4.9.jar",
+                "/mvnpm/vaadin-webcomponents-24.1.6.jar")));
+        final MvnpmInfo mvnpmInfo2 = readMvnpmInfo(getMvnpmInfoPath(tempDir));
+        assertEquals(3, mvnpmInfo2.installed().size());
+        final MvnpmInfo.InstalledDependency installedVaadin = mvnpmInfo2.installed().stream()
+                .filter(installedDependency -> installedDependency.id().equals("vaadin-webcomponents-24.1.6")).findFirst()
+                .get();
+        assertEquals(55, installedVaadin.dirs().size());
+        install(tempDir, getWebDependencies(
+                List.of("/mvnpm/react-bootstrap-2.7.4.jar", "/mvnpm/hooks-0.4.9.jar", "/mvnpm/moment-2.29.4-sources.jar")));
+        final MvnpmInfo mvnpmInfo3 = readMvnpmInfo(getMvnpmInfoPath(tempDir));
+        assertEquals(3, mvnpmInfo2.installed().size());
+        assertEquals(mvnpmInfo3.installed(),
+                Set.of(new MvnpmInfo.InstalledDependency("react-bootstrap-2.7.4", List.of("react-bootstrap")),
+                        new MvnpmInfo.InstalledDependency("hooks-0.4.9", List.of("@restart/hooks")),
+                        new MvnpmInfo.InstalledDependency("moment-2.29.4-sources", List.of("moment"))));
+        for (String dir : installedVaadin.dirs()) {
+            assertFalse(Files.exists(tempDir.resolve(dir)));
+        }
+    }
+
+    @Test
+    void testNoInfo() throws IOException {
+        Path tempDir = Files.createTempDirectory("testInstall");
+        install(tempDir, getWebDependencies(List.of("/mvnpm/stimulus-3.2.1.jar", "/mvnpm/hooks-0.4.9.jar")));
+        Files.deleteIfExists(getMvnpmInfoPath(tempDir));
+        install(tempDir, getWebDependencies(List.of("/mvnpm/react-bootstrap-2.7.4.jar", "/mvnpm/hooks-0.4.9.jar")));
+        final MvnpmInfo mvnpmInfo = readMvnpmInfo(getMvnpmInfoPath(tempDir));
+        assertEquals(2, mvnpmInfo.installed().size());
+        assertEquals(mvnpmInfo.installed(),
+                Set.of(new MvnpmInfo.InstalledDependency("react-bootstrap-2.7.4", List.of("react-bootstrap")),
+                        new MvnpmInfo.InstalledDependency("hooks-0.4.9", List.of("@restart/hooks"))));
+    }
+
+    private List<WebDependency> getWebDependencies(List<String> jarNames) {
+        return jarNames.stream().map(jarName -> {
+            try {
+                return new File(getClass().getResource(jarName).toURI()).toPath();
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }).map(d -> WebDependency.of(d, WebDependency.WebDependencyType.MVNPM)).toList();
+    }
+}

--- a/src/test/java/io/mvnpm/esbuild/resolve/BundleTester.java
+++ b/src/test/java/io/mvnpm/esbuild/resolve/BundleTester.java
@@ -3,12 +3,12 @@ package io.mvnpm.esbuild.resolve;
 import java.io.IOException;
 
 import io.mvnpm.esbuild.Bundler;
-import io.mvnpm.esbuild.util.Copy;
+import io.mvnpm.esbuild.util.PathUtils;
 
 public abstract class BundleTester {
 
     public static void cleanUp(String version) throws IOException {
-        Copy.deleteRecursive(BaseResolver.getLocation(version));
+        PathUtils.deleteRecursive(BaseResolver.getLocation(version));
     }
 
     public static void cleanUpDefault() throws IOException {

--- a/src/test/java/io/mvnpm/esbuild/util/PackageJsonTest.java
+++ b/src/test/java/io/mvnpm/esbuild/util/PackageJsonTest.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import io.mvnpm.esbuild.model.BundleType;
+import io.mvnpm.esbuild.model.WebDependency;
 
 class PackageJsonTest {
 
@@ -19,7 +19,8 @@ class PackageJsonTest {
     void findPackageMVNPMTest() throws URISyntaxException, IOException {
         final Path temp = Files.createTempDirectory("findPackageMVNPMTest");
         UnZip.unzip(new File(getClass().getResource("/mvnpm/react-bootstrap-2.7.4.jar").toURI()).toPath(), temp);
-        final Map<String, Path> packageNameAndRoot = JarInspector.findPackageNameAndRoot(temp, BundleType.MVNPM);
+        final Map<String, Path> packageNameAndRoot = JarInspector.findPackageNameAndRoot(temp,
+                WebDependency.WebDependencyType.MVNPM);
         assertFalse(packageNameAndRoot.isEmpty());
         Map.Entry<String, Path> next = packageNameAndRoot.entrySet().iterator().next();
         final String name = next.getKey();
@@ -30,7 +31,8 @@ class PackageJsonTest {
     void findPackageMVNPMCompositeTest() throws URISyntaxException, IOException {
         final Path temp = Files.createTempDirectory("findPackageMVNPMCompositeTest");
         UnZip.unzip(new File(getClass().getResource("/mvnpm/vaadin-webcomponents-24.1.6.jar").toURI()).toPath(), temp);
-        final Map<String, Path> packageNameAndRoot = JarInspector.findPackageNameAndRoot(temp, BundleType.MVNPM);
+        final Map<String, Path> packageNameAndRoot = JarInspector.findPackageNameAndRoot(temp,
+                WebDependency.WebDependencyType.MVNPM);
         assertFalse(packageNameAndRoot.isEmpty());
         assertTrue(packageNameAndRoot.size() > 1);
     }
@@ -39,7 +41,8 @@ class PackageJsonTest {
     void findPackageWebjarsTest() throws URISyntaxException, IOException {
         final Path temp = Files.createTempDirectory("findPackageWebjarsTest");
         UnZip.unzip(new File(getClass().getResource("/webjars/restart__hooks-0.4.9.jar").toURI()).toPath(), temp);
-        final Map<String, Path> packageNameAndRoot = JarInspector.findPackageNameAndRoot(temp, BundleType.WEBJARS);
+        final Map<String, Path> packageNameAndRoot = JarInspector.findPackageNameAndRoot(temp,
+                WebDependency.WebDependencyType.WEBJARS);
         assertFalse(packageNameAndRoot.isEmpty());
         Map.Entry<String, Path> next = packageNameAndRoot.entrySet().iterator().next();
         final String name = next.getKey();


### PR DESCRIPTION

- Using a mvnpm.json file to manage installed web dependencies (this is not to declare dependency just to keep track of what's installed)
- Can install in a different node_modules directory
- Re-install only what's needed (and delete what's unused).
- Resilient if the json file is broken
- Allow to identify WebDependencies with an id to avoid unnecessary file processing
- Allow to have different types (mvnpm/webjars) dependencies in the same bundle
- Support for grouped mvnpm deps
- Tests
- Remove need for apache common-text dependency