### PR TITLE
[Bug] Fallback method for moving files

### DIFF
--- a/src/main/java/io/mvnpm/esbuild/install/WebDepsInstaller.java
+++ b/src/main/java/io/mvnpm/esbuild/install/WebDepsInstaller.java
@@ -7,7 +7,6 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -79,7 +78,7 @@ public final class WebDepsInstaller {
                     dirs.add(packageName);
                     PathUtils.deleteRecursive(target);
                     Files.createDirectories(target.getParent());
-                    Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+                    PathUtils.safeMove(source, target);
                     logger.log(Level.FINE, "installed package ''{0}''", packageName);
                 }
                 installed.add(new MvnpmInfo.InstalledDependency(dep.id(), dirs));

--- a/src/main/java/io/mvnpm/esbuild/util/PathUtils.java
+++ b/src/main/java/io/mvnpm/esbuild/util/PathUtils.java
@@ -4,13 +4,21 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.io.InputStream;
+import java.nio.file.*;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 public class PathUtils {
+
+    private static final Logger logger = Logger.getLogger(PathUtils.class.getName());
 
     public static void copyEntries(Path rootDir, List<String> entries, Path targetDir) {
         for (String entry : entries) {
@@ -46,6 +54,100 @@ public class PathUtils {
             paths.sorted(Comparator.reverseOrder())
                     .map(Path::toFile)
                     .forEach(File::delete);
+
         }
+    }
+
+    /**
+     * Provides an implementation, based on {@link Files#move}, that is sensitive
+     * to failure and will try and mitigate or otherwise work around
+     * transient file system failures that would otherwise cause the
+     * build to fail. Implementing this should reduce frustration for
+     * users.
+     *
+     * @param source path to move
+     * @param target to move the path to
+     * @throws IOException when underlying io exceptions are encountered
+     */
+    public static void safeMove(final Path source, final Path target) throws IOException {
+        try {
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+        } catch (FileSystemException exception) {
+            // on windows, and possibly some other systems, it is possible that
+            // other processes (ide, antivirus, etc) could be accessing the
+            // file being deleted. this fallback method attempts to copy then
+            // delete instead of moving.
+            // the method of going and walking the entire file tree is used because
+            // some methods (like Files.copy) can silently fail when one file in the
+            // batch fails as in the PathUtilsTest.safeMoveWithContention case.
+            logger.log(Level.WARNING, "encountered ''{0}'' while moving ''{1}'' to ''{2}'', falling back to secondary method",
+                    new Object[] { exception.getClass().getName(), source, target });
+
+            // this is the list of the files that are copied and not moved so we
+            // need to attempt to delete them later
+            final List<Path> copied = new ArrayList<>(0);
+
+            try (Stream<Path> paths = Files.walk(source, FileVisitOption.FOLLOW_LINKS)) {
+                // copy each path to the matching target on the other side, log errors but keep going
+                for (final Path p : paths.toList()) {
+                    // no idea why this would happen
+                    if (!Files.exists(p)) {
+                        return;
+                    }
+                    final Path targetPath = target.resolve(source.relativize(p));
+                    if (Files.isDirectory(p)) {
+                        Files.createDirectories(targetPath);
+                    } else if (Files.isRegularFile(p)) {
+                        Files.createDirectories(targetPath.getParent());
+                        try {
+                            Files.move(p, targetPath, REPLACE_EXISTING);
+                        } catch (FileSystemException moveException) {
+                            Files.copy(p, targetPath, REPLACE_EXISTING);
+                            copied.add(p);
+                        }
+                    }
+                }
+            }
+
+            // clean up/delete *copied* files (not moved files) at the end
+            for (final Path toDelete : copied) {
+                try {
+                    Files.deleteIfExists(toDelete);
+                } catch (Exception ex) {
+                    logger.warning("could not delete ''{0}'' after copy");
+                }
+            }
+
+            // ensure source directory is gone
+            PathUtils.deleteRecursive(source);
+        }
+    }
+
+    /**
+     * Provides a SHA2-512 hash of the target path (if it is a file) and an
+     * empty string if it is not. Throws a runtime exception in the event that
+     * the SHA-512 algorithm cannot be used.
+     *
+     * @param target path to a file to get the hash of
+     * @return the hash, as a string of base64 characters, of the file. if it is not a file then an empty string is returned.
+     * @throws IOException in the event of an underlying IO error
+     * @throws RuntimeException if any runtime exception occurs or if the SHA-512 algorithm is not found
+     */
+    public static String hash(final Path target) throws IOException {
+        if (Files.isRegularFile(target)) {
+            try (final InputStream fileInputStream = Files.newInputStream(target, StandardOpenOption.READ)) {
+                final MessageDigest md = MessageDigest.getInstance("SHA-512");
+                final byte[] buffer = new byte[1024 * 16]; // buffer is just a guess
+                int read;
+                while ((read = fileInputStream.read(buffer)) >= 0) {
+                    md.update(buffer, 0, read);
+                }
+                byte[] digest = md.digest();
+                return Base64.getEncoder().encodeToString(digest);
+            } catch (NoSuchAlgorithmException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return "";
     }
 }

--- a/src/test/java/io/mvnpm/esbuild/util/PathUtilsTest.java
+++ b/src/test/java/io/mvnpm/esbuild/util/PathUtilsTest.java
@@ -1,0 +1,175 @@
+package io.mvnpm.esbuild.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class PathUtilsTest {
+
+    private static final Random rand = new Random();
+
+    /**
+     * Tests a straightforward move, with no expected issues
+     *
+     * @throws IOException when an underlying io error occurs
+     */
+    @Test
+    public void safeMove() throws IOException {
+
+        // create directory with files
+        final SafeMoveTestData data = createFiles("safeMove");
+        final Path source = data.source;
+        final Path target = source.resolveSibling("target");
+        Files.createDirectories(target);
+
+        // move files to new location
+        PathUtils.safeMove(source, target);
+
+        // ensure files are gone from source place and exist in target
+        checkSourceAndTarget(data, target);
+    }
+
+    /**
+     * Test with a file (or files) open to see what happens
+     *
+     * @throws IOException when an underlying io error occurs
+     */
+    @Test
+    public void safeMoveWithContention() throws IOException {
+
+        // create directory with files
+        final SafeMoveTestData data = createFiles("safeMoveWithContention");
+        final Path source = data.source;
+        final Path target = source.resolveSibling("target");
+        Files.createDirectories(target);
+
+        final Path fileToOpen = data.files.get(0);
+        try (
+                // open file
+                final InputStream hold = Files.newInputStream(fileToOpen)) {
+            try {
+                Files.move(source, target);
+                // this might be overkill...
+                Assertions.fail("expectation failed: no exception was thrown while moving under contention");
+            } catch (FileSystemException shouldAlwaysThrow) {
+                // no-op
+            }
+
+            // move files to new location
+            PathUtils.safeMove(source, target);
+        }
+
+        // ensure files are gone from source place and exist in target
+        checkSourceAndTarget(data, target);
+    }
+
+    /**
+     * Given the list of files and the source and target directories this allows both places
+     * to ensure that the files have been moved (and not left in) from the source directory to
+     * the target.
+     *
+     * @param data that was generated when the test files were created
+     * @param target root of target directory
+     */
+    private static void checkSourceAndTarget(SafeMoveTestData data, Path target) throws IOException {
+        final Path source = data.source;
+        // ensure files are gone from source place and exist in target
+        for (final Path sourcePath : data.files) {
+            if (Files.exists(sourcePath)) {
+                Assertions.fail("No source paths should exist after move: " + sourcePath + " still exists");
+            }
+            // create the target path by first finding the relative path from source base to actual file and then resolve that on the target path
+            final Path targetPath = target.resolve(source.relativize(sourcePath));
+            if (!Files.exists(targetPath)) {
+                Assertions.fail("Every source path should be moved, the path " + targetPath + " is missing");
+            }
+            final String sourceHash = data.hashes.get(sourcePath);
+            final String targetHash = PathUtils.hash(targetPath);
+
+            // typically you would do something like Assertions.equals(sourceHash, targetHash) but the output of that isn't particularly helpful
+            if (!Objects.equals(sourceHash, targetHash)) {
+                Assertions
+                        .fail(String.format("The content of '%s' does not match the content of '%s'", sourcePath, targetPath));
+            }
+        }
+    }
+
+    /**
+     * Simple data class to allow more information to be provided about the created test
+     * files.
+     */
+    private static class SafeMoveTestData {
+        Path source;
+
+        List<Path> files = new ArrayList<>();
+        Map<Path, String> hashes = new HashMap<>();
+    }
+
+    /**
+     * Create files for the test scenario
+     *
+     * @param testName so that the test directory can be named
+     * @return the data that was created during the test
+     * @throws IOException if an underlying io exception occurs
+     */
+    private SafeMoveTestData createFiles(final String testName) throws IOException {
+        // it is easier to find files if we use the maven target directory as our test root
+        final Path mvnTarget = Paths.get("./target");
+        Path root;
+        if (Files.exists(mvnTarget) && Files.isDirectory(mvnTarget)) {
+            final Path tmpRoot = mvnTarget.resolve("tmp");
+            Files.createDirectories(tmpRoot);
+            root = Files.createTempDirectory(tmpRoot, String.format("%s-test-", testName));
+        } else {
+            root = Files.createTempDirectory(String.format("%s-test-", testName));
+        }
+        Files.createDirectories(root);
+
+        // create source and target directories
+        final Path source = root.resolve("source");
+        Files.createDirectories(source);
+
+        // in the source directory create a bunch of files
+        final SafeMoveTestData data = new SafeMoveTestData();
+        data.source = source;
+
+        // this is our random data buffer, each file should be 8K just for checking that the
+        // file data doesn't cause issues
+        byte[] buffer = new byte[1024 * 8];
+
+        for (int idx = 0; idx < 100; idx++) {
+            Path sourceRoot = source;
+            int depth = 0;
+
+            // create arbitrary directories with a 50% chance of creating the next level up to a depth of 5
+            while (rand.nextBoolean() && depth < 5) {
+                sourceRoot = Files.createTempDirectory(sourceRoot, "dir-");
+                depth++;
+            }
+
+            // create the output file where we need it
+            final Path created = Files.createTempFile(sourceRoot, "temp-file-", ".data");
+
+            // add some random data to the file, this should cause most of the files to be the size of the buffer
+            // but some will have more and some could be large-ish.
+            do {
+                rand.nextBytes(buffer);
+                Files.write(created, buffer);
+            } while (rand.nextBoolean());
+
+            // keep the list of created files
+            data.files.add(created);
+            data.hashes.put(created, PathUtils.hash(created));
+        }
+
+        return data;
+    }
+
+}


### PR DESCRIPTION
On our Windows machines there is a sporadic issue that is likely caused by some sort of background scan. This prevents the move operation from working. Having a fallback for this specific case (copy then delete) allows the move to succeed and the build does not fail.