### PR TITLE
Make the watch process more consistant in case of errors

### DIFF
--- a/src/main/java/io/mvnpm/esbuild/BuildEventListener.java
+++ b/src/main/java/io/mvnpm/esbuild/BuildEventListener.java
@@ -1,9 +1,9 @@
 package io.mvnpm.esbuild;
 
-import java.util.Optional;
+import io.mvnpm.esbuild.model.WatchBuildResult;
 
 public interface BuildEventListener {
 
-    void onBuild(Optional<BundleException> error);
+    void onBuild(WatchBuildResult result);
 
 }

--- a/src/main/java/io/mvnpm/esbuild/Bundler.java
+++ b/src/main/java/io/mvnpm/esbuild/Bundler.java
@@ -12,10 +12,7 @@ import java.util.Properties;
 import java.util.logging.Logger;
 
 import io.mvnpm.esbuild.install.WebDepsInstaller;
-import io.mvnpm.esbuild.model.BundleOptions;
-import io.mvnpm.esbuild.model.BundleResult;
-import io.mvnpm.esbuild.model.EsBuildConfig;
-import io.mvnpm.esbuild.model.ExecuteResult;
+import io.mvnpm.esbuild.model.*;
 import io.mvnpm.esbuild.resolve.Resolver;
 
 public class Bundler {
@@ -91,8 +88,8 @@ public class Bundler {
         final Path dist = workDir.resolve(out);
         final EsBuildConfig esBuildConfig = prepareForBundling(bundleOptions, workDir, dist, true);
 
-        final Process process = esBuild(workDir, esBuildConfig, eventListener);
-        return new Watch(process, workDir, dist);
+        final WatchStartResult r = esBuildWatch(workDir, esBuildConfig, eventListener);
+        return new Watch(r.process(), workDir, dist, r.firstBuildResult());
     }
 
     private static Path getWorkDir(BundleOptions bundleOptions) throws IOException {
@@ -115,10 +112,10 @@ public class Bundler {
         deleteRecursive(nodeModulesDir);
     }
 
-    protected static Process esBuild(Path workDir, EsBuildConfig esBuildConfig, BuildEventListener listener)
+    protected static WatchStartResult esBuildWatch(Path workDir, EsBuildConfig esBuildConfig, BuildEventListener listener)
             throws IOException {
         final Execute execute = getExecute(workDir, esBuildConfig);
-        return execute.execute(listener);
+        return execute.watch(listener);
     }
 
     protected static ExecuteResult esBuild(Path workDir, EsBuildConfig esBuildConfig) throws IOException {

--- a/src/main/java/io/mvnpm/esbuild/Watch.java
+++ b/src/main/java/io/mvnpm/esbuild/Watch.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import io.mvnpm.esbuild.model.EntryPoint;
+import io.mvnpm.esbuild.model.WatchBuildResult;
 
 public class Watch {
 
@@ -13,10 +14,13 @@ public class Watch {
 
     private final Path dist;
 
-    public Watch(Process process, Path workDir, Path dist) {
+    private final WatchBuildResult firstBuildResult;
+
+    public Watch(Process process, Path workDir, Path dist, WatchBuildResult firstBuildResult) {
         this.process = process;
         this.workDir = workDir;
         this.dist = dist;
+        this.firstBuildResult = firstBuildResult;
     }
 
     public void updateEntries(List<EntryPoint> entries) throws IOException {
@@ -25,10 +29,29 @@ public class Watch {
 
     public void stop() {
         process.destroy();
+
+    }
+
+    public void waitForStop() {
+        process.destroy();
+        try {
+            process.waitFor();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
     }
 
     public Path workDir() {
         return workDir;
+    }
+
+    public WatchBuildResult firstBuildResult() {
+        return firstBuildResult;
+    }
+
+    public boolean isAlive() {
+        return process.isAlive();
     }
 
     public Path dist() {

--- a/src/main/java/io/mvnpm/esbuild/model/WatchBuildResult.java
+++ b/src/main/java/io/mvnpm/esbuild/model/WatchBuildResult.java
@@ -1,0 +1,13 @@
+package io.mvnpm.esbuild.model;
+
+import io.mvnpm.esbuild.BundleException;
+
+public record WatchBuildResult(String output, BundleException bundleException) {
+    public WatchBuildResult(String output) {
+        this(output, null);
+    }
+
+    public boolean isSuccess() {
+        return bundleException == null;
+    }
+}

--- a/src/main/java/io/mvnpm/esbuild/model/WatchStartResult.java
+++ b/src/main/java/io/mvnpm/esbuild/model/WatchStartResult.java
@@ -1,0 +1,4 @@
+package io.mvnpm.esbuild.model;
+
+public record WatchStartResult(WatchBuildResult firstBuildResult, Process process) {
+}


### PR DESCRIPTION
Now the watch method:
- waits for the first build and set the result, then it starts watching
- result contains an error in case of startup error and has a flag to indicate if its alive