### PR TITLE
Fix deadlock issue when watching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <esbuild.version>0.20.1-mvnpm-0.0.7</esbuild.version>
-    <quarkus.version>3.6.0</quarkus.version>
+    <quarkus.version>3.11.1</quarkus.version>
     <esbuild.scss.version>v0.0.7</esbuild.scss.version>
     <formatter.plugin.version>2.23.0</formatter.plugin.version>
     <impsort.plugin.version>1.9.0</impsort.plugin.version>

--- a/src/main/java/io/mvnpm/esbuild/Watch.java
+++ b/src/main/java/io/mvnpm/esbuild/Watch.java
@@ -1,22 +1,24 @@
 package io.mvnpm.esbuild;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
 import io.mvnpm.esbuild.model.EntryPoint;
 import io.mvnpm.esbuild.model.WatchBuildResult;
+import io.mvnpm.esbuild.model.WatchStartResult;
 
-public class Watch {
+public class Watch implements Closeable {
 
-    private final Process process;
+    private final WatchStartResult.WatchProcess process;
     private final Path workDir;
 
     private final Path dist;
 
     private final WatchBuildResult firstBuildResult;
 
-    public Watch(Process process, Path workDir, Path dist, WatchBuildResult firstBuildResult) {
+    public Watch(WatchStartResult.WatchProcess process, Path workDir, Path dist, WatchBuildResult firstBuildResult) {
         this.process = process;
         this.workDir = workDir;
         this.dist = dist;
@@ -27,19 +29,9 @@ public class Watch {
         entries.forEach(entry -> entry.process(workDir));
     }
 
-    public void stop() {
-        process.destroy();
-
-    }
-
-    public void waitForStop() {
-        process.destroy();
-        try {
-            process.waitFor();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-        }
+    @Override
+    public void close() throws IOException {
+        process.close();
     }
 
     public Path workDir() {
@@ -57,4 +49,5 @@ public class Watch {
     public Path dist() {
         return dist;
     }
+
 }

--- a/src/main/java/io/mvnpm/esbuild/model/WatchStartResult.java
+++ b/src/main/java/io/mvnpm/esbuild/model/WatchStartResult.java
@@ -1,4 +1,13 @@
 package io.mvnpm.esbuild.model;
 
-public record WatchStartResult(WatchBuildResult firstBuildResult, Process process) {
+import java.io.Closeable;
+
+public record WatchStartResult(WatchBuildResult firstBuildResult, WatchProcess process) {
+
+    public interface WatchProcess extends Closeable {
+
+        boolean isAlive();
+
+    }
+
 }

--- a/src/test/java/io/mvnpm/esbuild/BundlerTest.java
+++ b/src/test/java/io/mvnpm/esbuild/BundlerTest.java
@@ -111,7 +111,7 @@ public class BundlerTest {
         assertTrue(Files.readString(distApp).contains("alert(\"foo\");"));
 
         // then
-        watch.waitForStop();
+        watch.close();
 
         assertFalse(watch.isAlive());
     }
@@ -154,7 +154,7 @@ public class BundlerTest {
         assertTrue(Files.readString(distApp).contains("alert(\"foo\");"));
 
         // then
-        watch.stop();
+        watch.close();
     }
 
     @Test


### PR DESCRIPTION
Not closing the threads when closing the process was creating a deadlock.

The listener thread was blocked on an entrylock.
That was triggered by a new build of quarkus (which is also closing/stopping the watch to start a new one)
but the new build was not able to gain the single threead because it was locked :smile: