### PR TITLE
1.5.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 1.4.3
+  current-version: 1.5.0
   next-version: 999-SNAPSHOT


### PR DESCRIPTION
**Starting from 1.5.0 change to `esbuild-java-bundle-scss` to get the scss bundle as part of the Jar.
The core version will download it.**