### PR TITLE
Fix executable check

### DIFF
--- a/core/src/main/java/io/mvnpm/esbuild/resolve/BundledResolver.java
+++ b/core/src/main/java/io/mvnpm/esbuild/resolve/BundledResolver.java
@@ -20,7 +20,7 @@ public class BundledResolver implements Resolver {
     public Path resolve(String version) throws IOException {
         final Path path = getLocation(version);
         final Path executablePath = resolveExecutablePath(path);
-        if (Files.isExecutable(path)) {
+        if (Files.isExecutable(executablePath)) {
             return executablePath;
         }
 


### PR DESCRIPTION
There was a possibility to have the directory empty leading to an exception because the binary is not there when running