### PR TITLE
Release 2.1.3

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,4 @@
 release:
   current-version: 2.1.3
   next-version: 999-SNAPSHOT
+


### PR DESCRIPTION
## Summary
- Re-trigger 2.1.3 release after adding missing `<name>` element to vue locker POM