### PR TITLE
Fix Tailwind @source inline() not working

### DIFF
--- a/plugin-tailwind/plugin/src/main/resources/esbuild-plugin-tailwind.js
+++ b/plugin-tailwind/plugin/src/main/resources/esbuild-plugin-tailwind.js
@@ -140,7 +140,7 @@ class Root {
                 return [{ ...this.compiler.root, negated: false }, baseSource]
             })()
                 .concat(this.sources)
-                .concat(this.compiler.sources.map(s => ({ ...s, base: this.base })))
+                .concat(this.compiler.sources.map(s => s.pattern ? { ...s, base: this.base } : s))
             this.scanner = new Scanner({ sources })
             DEBUG && I.end('Setup scanner')
         }

--- a/plugin-tailwind/plugin/src/test/java/io/mvnpm/esbuild/BundlerTailwindTest.java
+++ b/plugin-tailwind/plugin/src/test/java/io/mvnpm/esbuild/BundlerTailwindTest.java
@@ -53,6 +53,26 @@ public class BundlerTailwindTest {
         assertTrue(options.workDir().resolve("dist").resolve("app.css").toFile().exists());
     }
 
+    @Test
+    void shouldBundleWithSourceInline() throws IOException, URISyntaxException {
+        final Path temp = Files.createTempDirectory("test-tailwind-source-inline");
+        final Path root = new File(BundlerTailwindTest.class.getResource("/tailwind-source-inline/").toURI()).toPath();
+        FileUtils.copyDirectory(root.toFile(), temp.toFile());
+
+        final BundleOptions options = BundleOptions.builder()
+                .withWorkDir(temp)
+                .withEsConfig(EsBuildConfig.builder().fixedEntryNames().build())
+                .addPlugin(new EsBuildPluginTailwind())
+                .addEntryPoint("app.js").build();
+
+        final BundleResult result = Bundler.bundle(options, true);
+        final Path cssOutput = options.workDir().resolve("dist").resolve("app.css");
+        assertTrue(cssOutput.toFile().exists());
+        final String css = Files.readString(cssOutput);
+        assertTrue(css.contains("underline"), "should contain underline utility from @source inline");
+        assertTrue(css.contains("font-bold"), "should contain font-bold utility from @source inline");
+    }
+
     static Path prepareTest() throws IOException, URISyntaxException {
         final Path temp = Files.createTempDirectory("test-tailwind");
         final Path root = new File(BundlerTailwindTest.class.getResource("/tailwind/").toURI()).toPath();

--- a/plugin-tailwind/plugin/src/test/resources/tailwind-source-inline/app.js
+++ b/plugin-tailwind/plugin/src/test/resources/tailwind-source-inline/app.js
@@ -1,0 +1,1 @@
+import './style.css';

--- a/plugin-tailwind/plugin/src/test/resources/tailwind-source-inline/style.css
+++ b/plugin-tailwind/plugin/src/test/resources/tailwind-source-inline/style.css
@@ -1,0 +1,2 @@
+@import "tailwindcss";
+@source inline("underline font-bold text-red-500");


### PR DESCRIPTION
## Summary

- Fix `@source inline("...")` directives being broken by the Tailwind plugin's source mapping, which was overriding `base` on all compiler sources (including inline ones that use `content` instead of `base`/`pattern`)
- Add test verifying that utilities declared via `@source inline()` appear in the bundled CSS output