### PR TITLE
Exclude old tailwindcss v3 transitive from @tailwindcss/typography

### DIFF
--- a/plugin-tailwind/locker/pom.xml
+++ b/plugin-tailwind/locker/pom.xml
@@ -15,11 +15,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.mvnpm.at.isaacs</groupId>
-                <artifactId>fs-minipass</artifactId>
-                <version>4.0.1</version>
-            </dependency>
-            <dependency>
                 <groupId>org.mvnpm.at.jridgewell</groupId>
                 <artifactId>gen-mapping</artifactId>
                 <version>0.3.13</version>
@@ -61,11 +56,6 @@
             </dependency>
             <dependency>
                 <groupId>org.mvnpm</groupId>
-                <artifactId>chownr</artifactId>
-                <version>3.0.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mvnpm</groupId>
                 <artifactId>cssesc</artifactId>
                 <version>3.0.0</version>
             </dependency>
@@ -77,7 +67,7 @@
             <dependency>
                 <groupId>org.mvnpm</groupId>
                 <artifactId>enhanced-resolve</artifactId>
-                <version>5.20.0</version>
+                <version>5.24.1</version>
             </dependency>
             <dependency>
                 <groupId>org.mvnpm</groupId>
@@ -92,7 +82,7 @@
             <dependency>
                 <groupId>org.mvnpm</groupId>
                 <artifactId>jiti</artifactId>
-                <version>2.6.1</version>
+                <version>2.7.0</version>
             </dependency>
             <dependency>
                 <groupId>org.mvnpm</groupId>
@@ -106,18 +96,8 @@
             </dependency>
             <dependency>
                 <groupId>org.mvnpm</groupId>
-                <artifactId>minipass</artifactId>
-                <version>7.1.3</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mvnpm</groupId>
-                <artifactId>minizlib</artifactId>
-                <version>3.1.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mvnpm</groupId>
                 <artifactId>postcss-selector-parser</artifactId>
-                <version>7.1.1</version>
+                <version>6.0.10</version>
             </dependency>
             <dependency>
                 <groupId>org.mvnpm</groupId>
@@ -132,22 +112,12 @@
             <dependency>
                 <groupId>org.mvnpm</groupId>
                 <artifactId>tapable</artifactId>
-                <version>2.3.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mvnpm</groupId>
-                <artifactId>tar</artifactId>
-                <version>7.5.9</version>
+                <version>2.3.3</version>
             </dependency>
             <dependency>
                 <groupId>org.mvnpm</groupId>
                 <artifactId>util-deprecate</artifactId>
                 <version>1.0.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mvnpm</groupId>
-                <artifactId>yallist</artifactId>
-                <version>5.0.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/plugin-tailwind/plugin/pom.xml
+++ b/plugin-tailwind/plugin/pom.xml
@@ -44,6 +44,13 @@
                     <groupId>org.mvnpm.at.isaacs</groupId>
                     <artifactId>cliui</artifactId>
                 </exclusion>
+                <!-- typography declares a peer dep on old tailwindcss v3 ([3.0.0,)),
+                     which pulls a deep transitive chain (cosmiconfig -> import-fresh -> resolve-from)
+                     that fails to resolve on fresh builds. We use tailwindcss v4 via @tailwindcss/node. -->
+                <exclusion>
+                    <groupId>org.mvnpm</groupId>
+                    <artifactId>tailwindcss</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary

- Exclude `org.mvnpm:tailwindcss` (v3) from `@tailwindcss/typography:0.5.19` to prevent it from pulling a deep transitive chain (`cosmiconfig` -> `import-fresh` -> `resolve-from`) that fails on fresh builds because `resolve-from:[4.0.0,5)` can't be resolved from Maven Central metadata
- Remove 6 stale deps from the locker that came from the old tailwindcss v3 chain (`fs-minipass`, `chownr`, `minipass`, `minizlib`, `tar`, `yallist`)
- Update locker versions to match the current unlocked dependency tree